### PR TITLE
Restyled entities

### DIFF
--- a/css/yzecoriolis.css
+++ b/css/yzecoriolis.css
@@ -1112,6 +1112,18 @@
   padding: 0 5px 0 5px;
   margin-right: 10px;
 }
+
+.yzecoriolis.sheet.actor .sheet-body a.entity-link {
+  background-color: rgba(113, 130, 190, 0.44);
+  border: 0px;
+  border-radius: 3px;
+  padding: 1px 6px;
+}
+  
+  .yzecoriolis.sheet.actor .sheet-body a.entity-link i {
+  color: #ffffff;
+}
+
 .yzecoriolis.sheet.actor .sheet-body .talent-list {
   list-style: none;
   overflow-y: auto;

--- a/css/yzecoriolis.css
+++ b/css/yzecoriolis.css
@@ -1112,18 +1112,15 @@
   padding: 0 5px 0 5px;
   margin-right: 10px;
 }
-
 .yzecoriolis.sheet.actor .sheet-body a.entity-link {
   background-color: rgba(113, 130, 190, 0.44);
   border: 0px;
   border-radius: 3px;
   padding: 1px 6px;
 }
-  
   .yzecoriolis.sheet.actor .sheet-body a.entity-link i {
   color: #ffffff;
 }
-
 .yzecoriolis.sheet.actor .sheet-body .talent-list {
   list-style: none;
   overflow-y: auto;


### PR DESCRIPTION
I use a lot of cross-entity links in my compendiums. The current entity links are unstyled, like this:
![image](https://user-images.githubusercontent.com/9035575/105616719-3e555c00-5dd9-11eb-9c33-4c49f424ae2a.png)

So I edited yzecoriolis.css so to make them more readable, reusing colors already used in the sheet:
![image](https://user-images.githubusercontent.com/9035575/105616735-59c06700-5dd9-11eb-8eda-fd76ee6d8374.png)