### PR TITLE
Removes a darkness point when NPCs reroll

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -444,6 +444,7 @@ export class yzecoriolisActorSheet extends ActorSheet {
       bonus: dataset.bonus ? Number(dataset.bonus) : 0,
       rollTitle: dataset.label,
       pushed: false,
+      actorType: this.actor.data.type,
     };
     const chatOptions = this.actor._prepareChatRollOptions(
       "systems/yzecoriolis/templates/sidebar/roll.html",

--- a/module/coriolis-roll.js
+++ b/module/coriolis-roll.js
@@ -139,7 +139,11 @@ export async function coriolisPushRoll(chatMessage, origRollData, origRoll) {
   await showDiceSoNice(origRoll, chatMessage.rollMode);
   const result = evaluateCoriolisRoll(origRollData, origRoll);
   await updateChatMessage(chatMessage, result);
-  await addDarknessPoints(1);
+  if(origRollData.actorType === "npc"){
+    await addDarknessPoints(-1);
+  }else {
+    await addDarknessPoints(1);
+  }
 }
 
 /**


### PR DESCRIPTION
Solves #59.

Simply adds actor type to the roll data and then checks it in the reroll.