### PR TITLE
feat: add related skill icon on prayer button

### DIFF
--- a/module/config.js
+++ b/module/config.js
@@ -281,6 +281,25 @@ YZECORIOLIS.icons = {
   faceless: "YZECORIOLIS.IconFaceless",
 };
 
+YZECORIOLIS.skillIcons = {
+  dexterity: "dancer",
+  force: "deckhand",
+  infiltration: "faceless",
+  manipulation: "merchant",
+  meleecombat: "dancer",
+  observation: "gambler",
+  rangedcombat: "judge",
+  survival: "traveler",
+  command: "judge",
+  culture: "traveler",
+  datadjinn: "messenger",
+  medicurgy: "ladyOfTears",
+  mysticpowers: "faceless",
+  pilot: "gambler",
+  science: "messenger",
+  technology: "messenger",
+};
+
 // General types are just either required or optional modules.
 // Weapon types are a sub-category of modules that actually house weaponry.
 YZECORIOLIS.shipModuleCategories = {

--- a/module/coriolis-roll.js
+++ b/module/coriolis-roll.js
@@ -234,6 +234,7 @@ async function showChatMessage(chatMsgOptions, resultData) {
   );
   let chatData = {
     title: getRollTitle(resultData.rollData),
+    icon: getRollIconKey(resultData.rollData),
     results: resultData,
     tooltip: tooltip,
     canPush: !resultData.pushed,
@@ -284,6 +285,11 @@ async function updateChatMessage(chatMessage, resultData) {
 
 function getRollTitle(rollData) {
   return `${rollData.rollTitle}`;
+}
+
+function getRollIconKey(rollData) {
+  const icon = CONFIG.YZECORIOLIS.skillIcons[rollData.skillKey];
+  return icon ? CONFIG.YZECORIOLIS.icons[icon] : "";
 }
 
 function getTooltipData(results) {

--- a/templates/sidebar/roll.html
+++ b/templates/sidebar/roll.html
@@ -12,7 +12,14 @@
         {{/if}}
         {{{tooltip}}}
         {{#if canPush}}
-        <div class="dice-formula dice-push yzecoriolis"><a>{{localize "YZECORIOLIS.PrayToIcons"}}</a></div>
+        <div class="dice-formula dice-push yzecoriolis">
+            <a>
+                <span>{{localize "YZECORIOLIS.PrayToIcons"}}</span>
+                {{#if icon}}
+                <span> - {{icon}}</span>
+                {{/if}}
+            </a>
+        </div>
         {{else}}
         <div class="dice-formula dice-push yzecoriolis"><em>{{localize "YZECORIOLIS.PushedRoll"}}</em></div>
         {{/if}}


### PR DESCRIPTION
Small PR to add the name of the icon related to the rolled skill on the prayer button (core book table 3.2, p 57).

This is mostly for flavor, but might be relevant when adding bonuses to prayers as these are icon specific.

<img width="281" alt="Screen Shot 2022-03-28 at 2 37 24 PM" src="https://user-images.githubusercontent.com/408380/160464349-7a4ae327-f282-45df-bcc2-d89030f983ab.png">

