### PR TITLE
Add automatic fire

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -387,5 +387,7 @@
   "YZECORIOLIS.ShipDeleteProblem": "Problem löschen",
 
   "YZECORIOLIS.ItemDeleteConfirmationTitle": "Element löschen",
-  "YZECORIOLIS.ItemDeleteConfirmationContent": "Möchten Sie dieses Element wirklich löschen?"
+  "YZECORIOLIS.ItemDeleteConfirmationContent": "Möchten Sie dieses Element wirklich löschen?",
+  "YZECORIOLIS.AutomaticFire": "Automatisches Feuer",
+  "YZECORIOLIS.AutomaticFireIgnoredOnes": "Anzahl ignorierter 1 (max 2)"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -392,5 +392,7 @@
   "YZECORIOLIS.ShipDeleteProblem": "Delete Problem",
 
   "YZECORIOLIS.ItemDeleteConfirmationTitle": "Delete Item",
-  "YZECORIOLIS.ItemDeleteConfirmationContent": "Are you sure you want to delete this item?"
+  "YZECORIOLIS.ItemDeleteConfirmationContent": "Are you sure you want to delete this item?",
+  "YZECORIOLIS.AutomaticFire": "Automatic fire",
+  "YZECORIOLIS.AutomaticFireIgnoredOnes": "Number of ignored 1s (max 2)"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -324,5 +324,7 @@
   "YZECORIOLIS.MigratedDP": "Sistema de Puntos de Oscuridad Migrado.",
 
   "YZECORIOLIS.ItemDeleteConfirmationTitle": "Eliminar elemento",
-  "YZECORIOLIS.ItemDeleteConfirmationContent": "¿Está seguro de que desea eliminar este elemento?"
+  "YZECORIOLIS.ItemDeleteConfirmationContent": "¿Está seguro de que desea eliminar este elemento?",
+  "YZECORIOLIS.AutomaticFire": "Fuego automático",
+  "YZECORIOLIS.AutomaticFireIgnoredOnes": "Número de 1 ignorados (máx. 2)"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -381,5 +381,7 @@
   "YZECORIOLIS.ShipDeleteProblem": "Supprimer Problème",
 
   "YZECORIOLIS.ItemDeleteConfirmationTitle": "Supprimer Item",
-  "YZECORIOLIS.ItemDeleteConfirmationContent": "Êtes-vous certain de vouloir supprimer cet item?"
+  "YZECORIOLIS.ItemDeleteConfirmationContent": "Êtes-vous certain de vouloir supprimer cet item?",
+  "YZECORIOLIS.AutomaticFire": "Tir automatique",
+  "YZECORIOLIS.AutomaticFireIgnoredOnes": "Nombre de 1 ignorés (max 2)"
 }

--- a/lang/pt-br.json
+++ b/lang/pt-br.json
@@ -381,5 +381,7 @@
   "YZECORIOLIS.ShipDeleteProblem": "Remover Problema",
 
   "YZECORIOLIS.ItemDeleteConfirmationTitle": "Excluir item",
-  "YZECORIOLIS.ItemDeleteConfirmationContent": "Tem certeza de que deseja excluir este item?"
+  "YZECORIOLIS.ItemDeleteConfirmationContent": "Tem certeza de que deseja excluir este item?",
+  "YZECORIOLIS.AutomaticFire": "Fogo automático",
+  "YZECORIOLIS.AutomaticFireIgnoredOnes": "Número de 1s ignorados (max 2)"
 }

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -381,5 +381,7 @@
   "YZECORIOLIS.ShipDeleteProblem": "Ta bort problem",
 
   "YZECORIOLIS.ItemDeleteConfirmationTitle": "Ta bort elementet",
-  "YZECORIOLIS.ItemDeleteConfirmationContent": "Är du säker på att du vill ta bort det här elementet?"
+  "YZECORIOLIS.ItemDeleteConfirmationContent": "Är du säker på att du vill ta bort det här elementet?",
+  "YZECORIOLIS.AutomaticFire": "Automatisk eld",
+  "YZECORIOLIS.AutomaticFireIgnoredOnes": "Antal ignorerade 1:or (max 2)"
 }

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -476,6 +476,7 @@ export class yzecoriolisActorSheet extends ActorSheet {
     const element = event.currentTarget;
     const dataset = element.dataset;
     const actorData = this.actor.data.data;
+    const automaticWeapon = dataset.automaticweapon === "true";
     const rollData = {
       rollType: dataset.rolltype,
       skillKey: dataset.skillkey,
@@ -494,10 +495,11 @@ export class yzecoriolisActorSheet extends ActorSheet {
       "systems/yzecoriolis/templates/sidebar/roll.html",
       dataset.rolltype
     );
-    coriolisModifierDialog((modifier) => {
+    coriolisModifierDialog((modifier, additionalData) => {
       rollData.modifier = modifier;
+      rollData.additionalData = additionalData;
       coriolisRoll(chatOptions, rollData);
-    });
+    }, automaticWeapon);
   }
 
   /**

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -62,10 +62,11 @@ export class yzecoriolisItem extends Item {
       "systems/yzecoriolis/templates/sidebar/roll.html",
       rollType
     );
-    coriolisModifierDialog((modifier) => {
+    coriolisModifierDialog((modifier, additionalData) => {
       rollData.modifier = modifier;
+      rollData.additionalData = additionalData;
       coriolisRoll(chatOptions, rollData);
-    });
+    }, itemData.automatic);
   }
 
   getChatData(htmlOptions) {

--- a/module/templates.js
+++ b/module/templates.js
@@ -14,6 +14,8 @@ export const preloadHandlerbarsTemplates = async function () {
     "systems/yzecoriolis/templates/actor/parts/ship-features.html",
     "systems/yzecoriolis/templates/actor/parts/ship-critical-damage.html",
     "systems/yzecoriolis/templates/actor/parts/ship-problems.html",
+    // dialog templates
+    "systems/yzecoriolis/templates/dialog/automatic-fire.html",
   ];
 
   return loadTemplates(templatePaths);

--- a/module/yzecoriolis.js
+++ b/module/yzecoriolis.js
@@ -148,13 +148,9 @@ Hooks.once("init", async function () {
     return CONFIG.YZECORIOLIS.attributeRolls[attributeKey];
   });
 
-    
-  Handlebars.registerHelper(
-    "getItemTypeName",
-    function (itemTypeKey) {
-      return CONFIG.YZECORIOLIS.itemTypes[itemTypeKey];
-    }
-  );
+  Handlebars.registerHelper("getItemTypeName", function (itemTypeKey) {
+    return CONFIG.YZECORIOLIS.itemTypes[itemTypeKey];
+  });
 
   Handlebars.registerHelper(
     "getTalentCategoryName",

--- a/templates/actor/parts/actor-gear.html
+++ b/templates/actor/parts/actor-gear.html
@@ -79,10 +79,12 @@
                 <div class="gear-bg {{weapon.data.toggleClass}} flickering flexrow">
                     <div class="gear-name flexrow">
                         <div class="gear-img-container rollable" style="background-image: url({{weapon.img}})"
-                            data-rolltype="weapon" data-label="{{weapon.name}}"
+                            data-rolltype="weapon" 
+                            data-label="{{weapon.name}}"
                             data-skillkey="{{getSkillKeyForWeaponType weapon.data.melee}}"
                             data-attributekey="{{getAttributeKeyForWeaponType weapon.data.melee}}"
-                            data-bonus="{{weapon.data.bonus}}">
+                            data-bonus="{{weapon.data.bonus}}"
+                            data-automaticWeapon="{{weapon.data.automatic}}">
                         </div>
                         <span class="expandable-info">{{weapon.name}}</span>
                     </div>

--- a/templates/dialog/automatic-fire.html
+++ b/templates/dialog/automatic-fire.html
@@ -1,0 +1,8 @@
+<div style="height: 30px">
+    <label>{{localize "YZECORIOLIS.AutomaticFire"}}</label>
+    <input type='checkbox' name='automaticFire' data-dtype='Boolean' />
+    <span class='ignoredOnes' hidden style="display: none">
+    <label>{{localize "YZECORIOLIS.AutomaticFireIgnoredOnes"}} :</label>
+    <input name='numberOfIgnoredOnes' style="width: 20px" type="number" min="0" max="2" data-dtype='Number' value="0"/>
+    </span>
+</div>


### PR DESCRIPTION
Added a new checkbox on the modifier dialog only if the weapon is automatic.

<img width="798" alt="Screen Shot 2022-05-19 at 4 50 27 PM" src="https://user-images.githubusercontent.com/408380/169402408-364890e8-84a6-492e-88ce-c75f05369fd5.png">

If automatic fire is used, allow to specify the number of 1 to ignore (to take into account high capacity weapon and machine gunner talent).

<img width="798" alt="Screen Shot 2022-05-19 at 4 50 39 PM" src="https://user-images.githubusercontent.com/408380/169402421-7d3078e7-d50a-4b59-acaa-6a16319c45b6.png">

Initial roll where we can see the extra rolls for the automatic fire.
<img width="283" alt="Screen Shot 2022-05-19 at 4 50 52 PM" src="https://user-images.githubusercontent.com/408380/169402431-dce51828-812b-43c8-902e-5a9e3d3797b2.png">

Prayer bonuses are only applied to the skill roll (not the automatic fire roll), but automatic fire dices are rerolled is needed.

<img width="288" alt="Screen Shot 2022-05-19 at 4 51 07 PM" src="https://user-images.githubusercontent.com/408380/169402440-4f9841c6-7ba7-4826-af3d-a4aaf6327f23.png">

