### PR TITLE
New option for initiative

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -357,6 +357,8 @@
   "YZECORIOLIS.MaxHullPoints": "Max. Rumpfpunkte",
 
   "YZECORIOLIS.SettingMaxEnergyPoints": "Maximal erlaubte Leistungspunkte",
+  "YZECORIOLIS.SettingInitiative": "Initiative",
+  "YZECORIOLIS.SettingInitiativeHint": "VerÃ¤ndert den Initiativ-Wurf. Standard: 1d6, Alternativ (mit einer Nachkommastelle): 1d6+(1d6*0.1)",
 
   "YZECORIOLIS.EnergyPointsReset": "Zuvor der Mannschaft zu geordnete Leistungspunkte stehen dem Schiffsreaktor wieder zur Verfügung.",
   "YZECORIOLIS.InvalidEPPermissions": "Du hast keine Berechtigung die LP-Verteilung zu verändern.",

--- a/lang/de.json
+++ b/lang/de.json
@@ -357,8 +357,8 @@
   "YZECORIOLIS.MaxHullPoints": "Max. Rumpfpunkte",
 
   "YZECORIOLIS.SettingMaxEnergyPoints": "Maximal erlaubte Leistungspunkte",
-  "YZECORIOLIS.SettingInitiative": "Initiative",
-  "YZECORIOLIS.SettingInitiativeHint": "VerÃ¤ndert den Initiativ-Wurf. Standard: 1d6, Alternativ (mit einer Nachkommastelle): 1d6+(1d6*0.1)",
+  "YZECORIOLIS.SettingInitiative": "Alternativer Initiativewurf",
+  "YZECORIOLIS.SettingInitiativeHint": "Nutze 1d6+(1d6*0.1) für den Initiativewurf anstatt 1d6 um Gleichstände zu vermeiden.",
 
   "YZECORIOLIS.EnergyPointsReset": "Zuvor der Mannschaft zu geordnete Leistungspunkte stehen dem Schiffsreaktor wieder zur Verfügung.",
   "YZECORIOLIS.InvalidEPPermissions": "Du hast keine Berechtigung die LP-Verteilung zu verändern.",

--- a/lang/de.json
+++ b/lang/de.json
@@ -357,8 +357,8 @@
   "YZECORIOLIS.MaxHullPoints": "Max. Rumpfpunkte",
 
   "YZECORIOLIS.SettingMaxEnergyPoints": "Maximal erlaubte Leistungspunkte",
-  "YZECORIOLIS.SettingInitiative": "Alternativer Initiativewurf",
-  "YZECORIOLIS.SettingInitiativeHint": "Nutze 1d6+(1d6*0.1) für den Initiativewurf anstatt 1d6 um Gleichstände zu vermeiden.",
+  "YZECORIOLIS.SettingAlternativeInitiative": "Alternativer Initiativewurf",
+  "YZECORIOLIS.SettingAlternativeInitiativeHint": "Nutze 1d6+(1d6*0.1) für den Initiativewurf anstatt 1d6 um Gleichstände zu vermeiden.",
 
   "YZECORIOLIS.EnergyPointsReset": "Zuvor der Mannschaft zu geordnete Leistungspunkte stehen dem Schiffsreaktor wieder zur Verfügung.",
   "YZECORIOLIS.InvalidEPPermissions": "Du hast keine Berechtigung die LP-Verteilung zu verändern.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -362,6 +362,8 @@
   "YZECORIOLIS.MaxHullPoints": "Max Hull Points",
 
   "YZECORIOLIS.SettingMaxEnergyPoints": "Maximum Allowed Energy Points",
+  "YZECORIOLIS.SettingInitiative": "Initiative",
+  "YZECORIOLIS.SettingInitiativeHint": "Changes the initiative-roll. Default: 1d6, Alternative (with one decimal place): 1d6+(1d6*0.1)",
 
   "YZECORIOLIS.EnergyPointsReset": "Energy Points previously assigned to crew returned to ship reactor.",
   "YZECORIOLIS.InvalidEPPermissions": "You do not have permission to change ship EP distribution.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -362,8 +362,8 @@
   "YZECORIOLIS.MaxHullPoints": "Max Hull Points",
 
   "YZECORIOLIS.SettingMaxEnergyPoints": "Maximum Allowed Energy Points",
-  "YZECORIOLIS.SettingInitiative": "Initiative",
-  "YZECORIOLIS.SettingInitiativeHint": "Changes the initiative-roll. Default: 1d6, Alternative (with one decimal place): 1d6+(1d6*0.1)",
+  "YZECORIOLIS.SettingInitiative": "Alternative initiative formula",
+  "YZECORIOLIS.SettingInitiativeHint": "Use 1d6+(1d6*0.1) for initiative instead of 1d6 to reduce the chances of a tie.",
 
   "YZECORIOLIS.EnergyPointsReset": "Energy Points previously assigned to crew returned to ship reactor.",
   "YZECORIOLIS.InvalidEPPermissions": "You do not have permission to change ship EP distribution.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -362,8 +362,8 @@
   "YZECORIOLIS.MaxHullPoints": "Max Hull Points",
 
   "YZECORIOLIS.SettingMaxEnergyPoints": "Maximum Allowed Energy Points",
-  "YZECORIOLIS.SettingInitiative": "Alternative initiative formula",
-  "YZECORIOLIS.SettingInitiativeHint": "Use 1d6+(1d6*0.1) for initiative instead of 1d6 to reduce the chances of a tie.",
+  "YZECORIOLIS.SettingAlternativeInitiative": "Alternative initiative formula",
+  "YZECORIOLIS.SettingAlternativeInitiativeHint": "Use 1d6+(1d6*0.1) for initiative instead of 1d6 to reduce the chances of a tie.",
 
   "YZECORIOLIS.EnergyPointsReset": "Energy Points previously assigned to crew returned to ship reactor.",
   "YZECORIOLIS.InvalidEPPermissions": "You do not have permission to change ship EP distribution.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -351,6 +351,8 @@
   "YZECORIOLIS.Notes": "Notes",
 
   "YZECORIOLIS.SettingMaxEnergyPoints": "Points d'Énergie Maximum",
+  "YZECORIOLIS.SettingAlternativeInitiative": "Formule d'initiative alternative",
+  "YZECORIOLIS.SettingAlternativeInitiativeHint": "Utiliser 1d6+(1d6*0.1) pour calculer l'initiative au lieu de 1d6 afin de réduire les chances d'égalité entre combatants.",
 
   "YZECORIOLIS.EnergyPointsReset": "Les Points d'Énergie assignés sont redirigés vers le réacteur du vaisseau.",
   "YZECORIOLIS.InvalidEPPermissions": "Vous n'avez pas la permission de changer la distribution des PE du vaisseau.",

--- a/module/settings.js
+++ b/module/settings.js
@@ -1,10 +1,5 @@
 export const registerSystemSettings = function () {
 
-  /*
-   * reloads the sheet after a certain setting is applied
-  */
-  const debouncedReload = foundry.utils.debounce(() => window.location.reload(), 100);
-
   /**
    * Track the system version upon which point a migration was last applied
    */
@@ -41,13 +36,27 @@ export const registerSystemSettings = function () {
     default: false,
   });
 
-  game.settings.register("yzecoriolis", "Initiative", {
-    name: game.i18n.localize("YZECORIOLIS.SettingInitiative"),
-    hint: game.i18n.localize("YZECORIOLIS.SettingInitiativeHint"),
+  game.settings.register("yzecoriolis", "AlternativeInitiative", {
+    name: game.i18n.localize("YZECORIOLIS.SettingAlternativeInitiative"),
+    hint: game.i18n.localize("YZECORIOLIS.SettingAlternativeInitiativeHint"),
     scope: "world",
     config: true,
     type: Boolean,
     default: false,
-    onChange: debouncedReload,
+    onChange: applyAlternativeInitiativeSetting,
   });
 };
+
+export function applyAlternativeInitiativeSetting() {
+  if (game.settings.get("yzecoriolis", "AlternativeInitiative")) {
+  CONFIG.Combat.initiative = {
+    formula: "1d6+(1d6*0.1)",
+    decimals: 1,
+  };
+} else {
+  CONFIG.Combat.initiative = {
+    formula: "1d6",
+    decimals: 0,
+  };
+}
+}

--- a/module/settings.js
+++ b/module/settings.js
@@ -1,4 +1,10 @@
 export const registerSystemSettings = function () {
+
+  /*
+   * reloads the sheet after a certain setting is applied
+  */
+  const debouncedReload = foundry.utils.debounce(() => window.location.reload(), 100);
+
   /**
    * Track the system version upon which point a migration was last applied
    */
@@ -33,5 +39,15 @@ export const registerSystemSettings = function () {
     config: false,
     type: Boolean,
     default: false,
+  });
+
+  game.settings.register("yzecoriolis", "Initiative", {
+    name: game.i18n.localize("YZECORIOLIS.SettingInitiative"),
+    hint: game.i18n.localize("YZECORIOLIS.SettingInitiativeHint"),
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false,
+    onChange: debouncedReload,
   });
 };

--- a/module/yzecoriolis.js
+++ b/module/yzecoriolis.js
@@ -35,15 +35,6 @@ Hooks.once("init", async function () {
     migrations: migrations,
   };
 
-  /**
-   * Set an initiative formula for the system
-   * @type {String}
-   */
-  CONFIG.Combat.initiative = {
-    formula: "1d6",
-    decimals: 0,
-  };
-
   // Setup TinyMCE stylings
   CONFIG.TinyMCE.content_css = "systems/yzecoriolis/css/yzecoriolismce.css";
 
@@ -87,6 +78,22 @@ Hooks.once("init", async function () {
     makeDefault: true,
     label: "SheetClassItem",
   });
+
+  /**
+   * Set an initiative formula for the system
+   * @type {String}
+   */
+  if (game.settings.get("yzecoriolis", "Initiative")) {
+    CONFIG.Combat.initiative = {
+      formula: "1d6",
+      decimals: 0,
+    };
+  } else {
+      CONFIG.Combat.initiative = {
+      formula: "1d6+(1d6*0.1)",
+      decimals: 1,
+    };
+  }
 
   // register turn order changes. Currently it's sorting from high->low so no need to edit atm.
   //Combat.prototype.setupTurns = setupCoriolisTurns;
@@ -148,7 +155,7 @@ Hooks.once("init", async function () {
     return CONFIG.YZECORIOLIS.attributeRolls[attributeKey];
   });
 
-    
+
   Handlebars.registerHelper(
     "getItemTypeName",
     function (itemTypeKey) {

--- a/module/yzecoriolis.js
+++ b/module/yzecoriolis.js
@@ -1,6 +1,9 @@
 // Import Modules
 import { YZECORIOLIS } from "./config.js";
-import { registerSystemSettings } from "./settings.js";
+import {
+  registerSystemSettings,
+  applyAlternativeInitiativeSetting,
+} from "./settings.js";
 import { yzecoriolisActor } from "./actor/actor.js";
 import { yzecoriolisActorSheet } from "./actor/actor-sheet.js";
 import { yzecoriolisShipSheet } from "./actor/ship-sheet.js";
@@ -79,21 +82,8 @@ Hooks.once("init", async function () {
     label: "SheetClassItem",
   });
 
-  /**
-   * Set an initiative formula for the system
-   * @type {String}
-   */
-  if (game.settings.get("yzecoriolis", "Initiative")) {
-    CONFIG.Combat.initiative = {
-      formula: "1d6",
-      decimals: 0,
-    };
-  } else {
-      CONFIG.Combat.initiative = {
-      formula: "1d6+(1d6*0.1)",
-      decimals: 1,
-    };
-  }
+  // Apply an initiative formula for the system from the settings
+  applyAlternativeInitiativeSetting();
 
   // register turn order changes. Currently it's sorting from high->low so no need to edit atm.
   //Combat.prototype.setupTurns = setupCoriolisTurns;
@@ -155,20 +145,13 @@ Hooks.once("init", async function () {
     return CONFIG.YZECORIOLIS.attributeRolls[attributeKey];
   });
 
-
-  Handlebars.registerHelper(
-    "getItemTypeName",
-    function (itemTypeKey) {
+  Handlebars.registerHelper("getItemTypeName", function (itemTypeKey) {
       return CONFIG.YZECORIOLIS.itemTypes[itemTypeKey];
-    }
-  );
+  });
 
-  Handlebars.registerHelper(
-    "getTalentCategoryName",
-    function (talentCategoryKey) {
+  Handlebars.registerHelper("getTalentCategoryName", function (talentCategoryKey) {
       return CONFIG.YZECORIOLIS.talentCategories[talentCategoryKey];
-    }
-  );
+  });
 
   Handlebars.registerHelper("getGearWeightName", function (gearWeight) {
     return CONFIG.YZECORIOLIS.gearWeights[gearWeight];


### PR DESCRIPTION
This gives an global option (for the GM) to changes the initiative roll from 1d6 to 1d6+(1d6*0.1).

With this the initiative has less chances of a draw. Similar when you would draw from the icon-carddeck.

![image](https://user-images.githubusercontent.com/36819852/170879791-5c341a96-210b-4e88-aaa9-94538e8688f2.png)
![image](https://user-images.githubusercontent.com/36819852/170879802-681a4d0e-6ae5-4fcb-83bb-d4d280c20043.png)
