### PR TITLE
better fitting of crew-portraits

### DIFF
--- a/css/yzecoriolis.css
+++ b/css/yzecoriolis.css
@@ -2383,8 +2383,7 @@
 }
 .yzecoriolis.sheet.actor .ship .crew-card .crew-portrait {
   max-height: 269px;
-  background-position: -77px -15px;
-  background-size: 180%;
+  background-size: cover;
   background-blend-mode: multiply;
   background-color: rgba(0, 0, 0, 0.35);
   transition: background-color 275ms ease;


### PR DESCRIPTION
This small change gives the crew-portraits a better fitting in the ship-sheet.
The fixed position and scaling looks with different portraits funny till worse (even with the original unknown_player.png)

**Original:**
![image](https://user-images.githubusercontent.com/36819852/171862154-13d659d7-1075-48b5-8a2a-8f6ffcb78d60.png)

**Optimised:**
![image](https://user-images.githubusercontent.com/36819852/171862239-94b95e6c-1fe4-4b36-98e2-6cdc286de832.png)
