### PR TITLE
Quick editing of initiative as it can often change during combat

### DIFF
--- a/module/hooks.js
+++ b/module/hooks.js
@@ -60,6 +60,27 @@ Hooks.on("createActor", async (entity, options, userId) => {
   }
 });
 
+Hooks.on("renderCombatTracker", (app, html, data) => {
+  const currentCombat = data.combats[data.currentIndex - 1];
+  if (currentCombat) {
+    html.find(".combatant").each((i, el) => {
+      const id = el.dataset.combatantId;
+      const combatant = currentCombat.data.combatants.find((c) => c.id === id);
+      const initDiv = el.getElementsByClassName("token-initiative")[0];
+      const initiative = combatant.initiative || "";
+      const readOnly = game.user.isGM ? "" : "readonly";
+      initDiv.innerHTML = `<input style="color: white; "type="number" ${readOnly} value="${initiative}">`;
+
+      initDiv.addEventListener("change", async (e) => {
+        const inputElement = e.target;
+        const combatantId = inputElement.closest("[data-combatant-id]").dataset
+          .combatantId;
+        await currentCombat.setInitiative(combatantId, inputElement.value);
+      });
+    });
+  }
+});
+
 function rerenderAllCrew() {
   // re render all characters/npcs to update their crew position drop downs.
   for (let e of game.actors.contents) {


### PR DESCRIPTION
![Screen Shot 2022-06-08 at 1 20 06 PM](https://user-images.githubusercontent.com/408380/172678336-67518eb7-21b4-4b2c-8ecb-4940255c798d.png)

This small change allows GM to easily edit the initiative score after it has been rolled. This is useful when the combatant changes weapon (with different initiative bonus) or uses extra successes to improve initiative.

Adapted from: https://github.com/sun-dragon-cult/fvtt-module-reverseinitiativeorder