### PR TITLE
added permanent HP/MP injuries + change input for Modifier

### DIFF
--- a/css/yzecoriolis.css
+++ b/css/yzecoriolis.css
@@ -90,6 +90,9 @@
 .flexcol .flex4 {
   flex: 4;
 }
+.flex-checkbox {
+  margin-right: 15px;
+}
 .debug {
   border: 1px solid red;
 }

--- a/css/yzecoriolis.css
+++ b/css/yzecoriolis.css
@@ -1719,11 +1719,44 @@
 }
 .yzecoriolis.sheet.actor .sheet-body .critical-injuries-list .injury {
   align-items: center;
-  background: rgba(19, 27, 53, 0.45);
   border-radius: 3px;
   padding: 2px;
-  margin-bottom: 2px;
+  margin-bottom: 5px;
   height: 26px;
+  color: white;
+}
+.yzecoriolis.sheet.actor .sheet-body .critical-injuries-list .critical-injuries-bg {
+  background-color: rgba(19, 27, 53, 0.45);
+  border-radius: 3px;
+  padding-left: 5px;
+  padding-right: 5px;
+  flex: 0 0 100%;
+}
+@keyframes flicker {
+  0% {
+    background-color: rgba(59, 84, 166, 0.45);
+  }
+  100% {
+    background-color: rgba(19, 27, 53, 0.45);
+  }
+}
+.yzecoriolis.sheet.actor .sheet-body .critical-injuries-list .critical-injuries-bg:hover {
+  animation: flicker 1.2s;
+  animation-fill-mode: forwards;
+}
+.yzecoriolis.sheet.actor .sheet-body .critical-injuries-list .critical-injuries-name {
+  font-family: "Cairo-SemiBold";
+  color: white;
+  color: #ffa903;
+  font-size: 15px;
+  cursor: pointer;
+  transition: transform 275ms ease;
+}
+.yzecoriolis.sheet.actor .sheet-body .critical-injuries-list .critical-injuries-name:hover {
+  transform: translateX(5px);
+}
+.yzecoriolis.sheet.actor .sheet-body .critical-injuries-list .expanded {
+  height: auto;
 }
 .yzecoriolis.sheet.actor .sheet-body .critical-injuries-list .crit-add-controls {
   font-family: "Cairo";

--- a/lang/de.json
+++ b/lang/de.json
@@ -331,6 +331,8 @@
 
   "YZECORIOLIS.MigratedDP": "Finsternispunkte-System wurde übertragen.",
   "YZECORIOLIS.HPBonus": "TP Bonus",
+  "YZECORIOLIS.HPInjury": "perm. TP-Abzug",
+  "YZECORIOLIS.MPInjury": "perm. WP-Abzug",
   "YZECORIOLIS.Melee": "Nahkampf",
 
   "YZECORIOLIS.SheetClassCharacter": "Coriolis Charakterbogen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -336,6 +336,8 @@
   "YZECORIOLIS.MigratedDP": "Darkness Points System Migrated.",
   "YZECORIOLIS.HPBonus": "HP Bonus",
   "YZECORIOLIS.MPBonus": "MP Bonus",
+  "YZECORIOLIS.HPInjury": "Perm. HP Reduction",
+  "YZECORIOLIS.MPInjury": "Perm. MP Reduction",
   "YZECORIOLIS.Melee": "Melee",
 
   "YZECORIOLIS.SheetClassCharacter": "Coriolis Character Sheet",

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -91,12 +91,18 @@ export class yzecoriolisActor extends Actor {
 
     let hpBonuses = this._prepHPBonuses();
     let mpBonuses = this._prepMPBonuses();
+    let hpInjuries = this._prepHPInjuries();
+    let mpInjuries = this._prepMPInjuries();
     data.hitPoints.max =
       data.attributes.strength.value +
       data.attributes.agility.value +
-      hpBonuses;
+      hpBonuses -
+      hpInjuries;
     data.mindPoints.max =
-      data.attributes.wits.value + data.attributes.empathy.value + mpBonuses;
+      data.attributes.wits.value +
+      data.attributes.empathy.value +
+      mpBonuses -
+      mpInjuries;
 
     if (data.hitPoints.value > data.hitPoints.max) {
       data.hitPoints.value = data.hitPoints.max;
@@ -169,6 +175,32 @@ export class yzecoriolisActor extends Actor {
     }
     return bonus;
   }
+
+  _prepHPInjuries() {
+  // look through injuries for any HP penalties
+  let bonus = 0;
+  for (let t of this.data.items) {
+    if (t.type !== "injury") {
+      continue;
+    }
+    const tData = t.data.data;
+    bonus += Number(tData.hpInjury);
+  }
+  return bonus;
+}
+
+_prepMPInjuries() {
+  // look through injuries for any MP penalties
+  let bonus = 0;
+  for (let t of this.data.items) {
+    if (t.type !== "injury") {
+      continue;
+    }
+    const tData = t.data.data;
+    bonus += Number(tData.mpInjury);
+  }
+  return bonus;
+}
 
   /** @override */
   static async create(data, options = {}) {

--- a/template.json
+++ b/template.json
@@ -287,7 +287,7 @@
     },
     "gear": {
       "templates": ["gear"],
-      "bonus": 0
+      "bonus": ""
     },
     "talent": {
       "templates": ["base"],
@@ -331,7 +331,9 @@
       "fatal": false,
       "timeLimit": "",
       "healTime": "",
-      "bonus": 0
+      "bonus": "",
+      "hpInjury": 0,
+      "mpInjury": 0
     },
     "shipProblem": {
       "templates": ["base"]

--- a/templates/actor/parts/actor-stats.html
+++ b/templates/actor/parts/actor-stats.html
@@ -74,21 +74,21 @@
             {{/if}}
         </li>
         {{#each injuries as |injury id|}}
-        <li class="injury fr-basic item" data-item-id="{{injury._id}}">
-            <div class="injury-display flex1">
-                <span>{{injury.name}}</span>
-            </div>
-            <div class="injury-description">
-                {{!-- we're putting in the raw output here since description is already html markup from tinyMCE--}}
-                <span>{{{injury.data.description}}}</span>
-            </div>
-            <div class="crit-controls">
-                <a class="crit-control-widget item-edit" title={{localize "YZECORIOLIS.EditCriticalInjury"}}>
-                    <i class="fas fa-edit"></i></a>
-                <a class="crit-control-widget item-post" title="{{localize "YZECORIOLIS.PostCriticalInjury"}}"><i
-                    class="fas fa-comment"></i></a>
-                <a class="crit-control-widget item-delete" title={{localize "YZECORIOLIS.DeleteCriticalInjury"}}><i
-                        class="fas fa-trash"></i></a>
+        <li class="injury item flexrow" data-item-id="{{injury._id}}">
+            <div class="critical-injuries-bg flickering flexrow">
+                <div class="critical-injuries-name expandable-info flexrow">
+                  <span>{{injury.name}}</span>
+                  <div class="injury-description">
+                    <span>{{log injury}}{{#if_eq injury.data.fatal true}}{{localize "YZECORIOLIS.FatalInjury"}}{{#if injury.data.timeLimit}} ({{injury.data.timeLimit}}){{/if}}!{{/if_eq}}</span>
+                  </div>
+                </div>
+                <div class="crit-controls">
+                    <a class="crit-control-widget item-edit" title="{{localize "YZECORIOLIS.EditCriticalInjury"}}"><i
+                            class="fas fa-edit"></i></a>
+                    <a class="crit-control-widget item-post" title="{{localize "YZECORIOLIS.PostCriticalInjury"}}"><i
+                            class="fas fa-comment"></i></a>
+                    <a class="crit-control-widget item-delete" title="{{localize "YZECORIOLIS.DeleteCriticalInjury"}}"><i class="fas fa-trash"></i></a>
+                </div>
             </div>
         </li>
         {{/each}}

--- a/templates/item/armor-sheet.html
+++ b/templates/item/armor-sheet.html
@@ -16,9 +16,11 @@
                     </select>
                 </div>
 
-                <div class="resource">
+                <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.Restricted"}}</label>
-                    <input type="checkbox" name="data.restricted" data-dtype="Boolean" {{checked data.restricted}} />
+                    <div class="flex-checkbox">
+                      <input type="checkbox" name="data.restricted" data-dtype="Boolean" {{checked data.restricted}} />
+                    </div>
                 </div>
 
 

--- a/templates/item/gear-sheet.html
+++ b/templates/item/gear-sheet.html
@@ -30,7 +30,7 @@
                 </div>
                 <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.Bonus"}}</label>
-                    <input type="text" name="data.bonus" value="{{data.bonus}}" data-dtype="Number" />
+                    <input type="text" name="data.bonus" value="{{data.bonus}}" data-dtype="String" />
                 </div>
                 <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.MoneyCost"}}</label>

--- a/templates/item/gear-sheet.html
+++ b/templates/item/gear-sheet.html
@@ -24,9 +24,11 @@
                         {{/select}}
                     </select>
                 </div>
-                <div class="resource">
+                <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.Restricted"}}</label>
-                    <input type="checkbox" name="data.restricted" data-dtype="Boolean" {{checked data.restricted}} />
+                    <div class="flex-checkbox">
+                      <input type="checkbox" name="data.restricted" data-dtype="Boolean" {{checked data.restricted}} />
+                    </div>
                 </div>
                 <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.Bonus"}}</label>

--- a/templates/item/injury-sheet.html
+++ b/templates/item/injury-sheet.html
@@ -7,7 +7,9 @@
         <div class="flexcol flex1">
             <div class="resource">
                 <label class="resource-label">{{localize "YZECORIOLIS.FatalInjury"}}</label>
-                <input type="checkbox" name="data.fatal" data-dtype="Boolean" {{checked data.fatal}} />
+                <div class="flex-checkbox">
+                  <input type="checkbox" name="data.fatal" data-dtype="Boolean" {{checked data.fatal}} />
+                </div>
             </div>
             <div class="resource numeric-input flexrow">
                 <label class="resource-label">{{localize "YZECORIOLIS.InjuryTimeLimitRoll"}}</label>

--- a/templates/item/injury-sheet.html
+++ b/templates/item/injury-sheet.html
@@ -21,7 +21,19 @@
             </div>
             <div class="resource numeric-input flexrow">
                 <label class="resource-label">{{localize "YZECORIOLIS.ModifierForRoll"}}</label>
-                <input type="number" min="0" name="data.bonus" value="{{data.bonus}}"
+                <input type="text" name="data.bonus" value="{{data.bonus}}"
+                    data-dtype="String" />
+            </div>
+            <div class="resource numeric-input flexrow">
+              <label class="resource-label">{{localize "YZECORIOLIS.HPInjury"}}</label>
+              <input type="number" name="data.hpInjury" value="{{data.hpInjury}}"
+                    placeholder="0" min="0" oninput="this.value = parseFloat(this.value).toFixed(0);"
+                    data-dtype="Number" />
+            </div>
+            <div class="resource numeric-input flexrow">
+              <label class="resource-label">{{localize "YZECORIOLIS.MPInjury"}}</label>
+              <input type="number" name="data.mpInjury" value="{{data.mpInjury}}"
+                    placeholder="0" min="0" oninput="this.value = parseFloat(this.value).toFixed(0);"
                     data-dtype="Number" />
             </div>
         </div>

--- a/templates/item/talent-sheet.html
+++ b/templates/item/talent-sheet.html
@@ -25,28 +25,33 @@
                         {{/select}}
                     </select>
                 </div>
+                {{else if_eq data.category 'cybernetic'}}
+                  <div class="resource flexrow">
+                    <label class="resource-label">{{localize "YZECORIOLIS.MoneyCost"}} ({{localize "YZECORIOLIS.Birr"}})</label>
+                    <input type="number" name="data.cost" value="{{data.cost}}"
+                        data-dtype="Number" />
+                  </div>
+                {{else if_eq data.category 'bionicsculpt'}}
+                  <div class="resource flexrow">
+                    <label class="resource-label">{{localize "YZECORIOLIS.MoneyCost"}} ({{localize "YZECORIOLIS.Birr"}})</label>
+                    <input type="number" name="data.cost" value="{{data.cost}}"
+                        data-dtype="Number" />
+                  </div>
+                {{else}}
+                  <div class="flexrow"></div>
                 {{/if_eq}}
                 {{!-- Edit HP Bonus for this talent --}}
                 <div class="resource flexrow">
-                    <label class="cost-label flexrow">{{localize "YZECORIOLIS.HPBonus"}}</label>
-                    <input class="cost-input flexrow" type="text" name="data.hpBonus" value="{{data.hpBonus}}"
+                    <label class="resource-label">{{localize "YZECORIOLIS.HPBonus"}}</label>
+                    <input type="number" name="data.hpBonus" value="{{data.hpBonus}}"
                         data-dtype="Number" />
                 </div>
                 {{!-- Edit MP Bonus for this talent --}}
                 <div class="resource flexrow">
-                    <label class="cost-label flexrow">{{localize "YZECORIOLIS.MPBonus"}}</label>
-                    <input class="cost-input flexrow" type="text" name="data.mpBonus" value="{{data.mpBonus}}"
+                    <label class="resource-label">{{localize "YZECORIOLIS.MPBonus"}}</label>
+                    <input type="number" name="data.mpBonus" value="{{data.mpBonus}}"
                         data-dtype="Number" />
                 </div>
-                {{!-- Display the cost if it has any --}}
-                {{#talentHasCost data.category}}
-                <div class="flexrow">
-                    <label class="cost-label flexrow">{{localize "YZECORIOLIS.MoneyCost"}}</label>
-                    <input class="cost-input flexrow" type="text" name="data.cost" value="{{data.cost}}"
-                        data-dtype="Number" />
-                    <label class="cost-currency-label flexrow">{{localize "YZECORIOLIS.Birr"}}</label>
-                </div>
-                {{/talentHasCost}}
             </div>
         </div>
     </header>

--- a/templates/item/weapon-sheet.html
+++ b/templates/item/weapon-sheet.html
@@ -59,9 +59,11 @@
                     </select>
                 </div>
 
-                <div class="resource">
+                <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.Restricted"}}</label>
-                    <input type="checkbox" name="data.restricted" data-dtype="Boolean" {{checked data.restricted}} />
+                    <div class="flex-checkbox">
+                      <input type="checkbox" name="data.restricted" data-dtype="Boolean" {{checked data.restricted}} />
+                    </div>
                 </div>
 
 
@@ -82,19 +84,25 @@
                     </select>
                 </div>
 
-                <div class="resource">
+                <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.Automatic"}}</label>
-                    <input type="checkbox" name="data.automatic" data-dtype="Boolean" {{checked data.automatic}} />
+                    <div class="flex-checkbox">
+                      <input type="checkbox" name="data.automatic" data-dtype="Boolean" {{checked data.automatic}} />
+                    </div>
                 </div>
 
-                <div class="resource">
+                <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.Explosive"}}</label>
-                    <input type="checkbox" name="data.explosive" data-dtype="Boolean" {{checked data.explosive}} />
+                    <div class="flex-checkbox">
+                      <input type="checkbox" name="data.explosive" data-dtype="Boolean" {{checked data.explosive}} />
+                    </div>
                 </div>
 
-                <div class="resource">
+                <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.Melee"}}</label>
-                    <input type="checkbox" name="data.melee" data-dtype="Boolean" {{checked data.melee}} />
+                    <div class="flex-checkbox">
+                      <input type="checkbox" name="data.melee" data-dtype="Boolean" {{checked data.melee}} />
+                    </div>
                 </div>
 
                 {{#if data.explosive}}

--- a/templates/sidebar/item.html
+++ b/templates/sidebar/item.html
@@ -12,18 +12,18 @@
         <h4>[ {{localize (getItemTypeName item.type)}} ]</h4>
         {{/if}}
         {{/if_eq}}
-    </div> 
-    
+    </div>
+
     <!-- ARMOR DATA -->
     {{#if_eq item.type 'armor'}}
     <div>
         {{#if item.data.restricted}}
-        <p><strong>{{localize "YZECORIOLIS.Restricted"}}</strong></p> 
+        <p><strong>{{localize "YZECORIOLIS.Restricted"}}</strong></p>
         {{/if}}
-        <p><strong>{{localize "YZECORIOLIS.TechTier"}} : </strong>{{getTechTierName item.data.techTier}}</p>  
+        <p><strong>{{localize "YZECORIOLIS.TechTier"}} : </strong>{{getTechTierName item.data.techTier}}</p>
         <p><strong>{{localize "YZECORIOLIS.ArmorRating"}}: </strong>{{item.data.armorRating}}</p>
-        <p><strong>{{localize "YZECORIOLIS.Weight"}} : </strong>{{ getWeightName item.data.weight}}</p>  
-        <p><strong>{{localize "YZECORIOLIS.Cost"}} : </strong>{{item.data.cost}} {{localize "YZECORIOLIS.Birr"}}</p>  
+        <p><strong>{{localize "YZECORIOLIS.Weight"}} : </strong>{{ getWeightName item.data.weight}}</p>
+        <p><strong>{{localize "YZECORIOLIS.Cost"}} : </strong>{{item.data.cost}} {{localize "YZECORIOLIS.Birr"}}</p>
     </div>
     {{/if_eq}}
 
@@ -31,11 +31,14 @@
     {{#if_eq item.type 'gear'}}
     <div>
         {{#if item.data.restricted}}
-        <p><strong>{{localize "YZECORIOLIS.Restricted"}}</strong></p>  
+        <p><strong>{{localize "YZECORIOLIS.Restricted"}}</strong></p>
         {{/if}}
-        <p><strong>{{localize "YZECORIOLIS.TechTier"}} : </strong>{{getTechTierName item.data.techTier}}</p>  
-        <p><strong>{{localize "YZECORIOLIS.Weight"}} : </strong>{{ getWeightName item.data.weight}}</p>  
-        <p><strong>{{localize "YZECORIOLIS.Cost"}} : </strong>{{item.data.cost}} {{localize "YZECORIOLIS.Birr"}}</p>  
+        <p><strong>{{localize "YZECORIOLIS.TechTier"}} : </strong>{{getTechTierName item.data.techTier}}</p>
+        <p><strong>{{localize "YZECORIOLIS.Weight"}} : </strong>{{ getWeightName item.data.weight}}</p>
+        <p><strong>{{localize "YZECORIOLIS.Cost"}} : </strong>{{item.data.cost}} {{localize "YZECORIOLIS.Birr"}}</p>
+        {{#if item.data.bonus}}
+        <p><strong>{{localize "YZECORIOLIS.Bonus"}} : </strong>{{item.data.bonus}}</p>
+        {{/if}}
     </div>
     {{/if_eq}}
 
@@ -43,10 +46,19 @@
     {{#if_eq item.type 'injury'}}
     <div>
         {{#if item.data.fatal}}
-        <p><strong>{{localize "YZECORIOLIS.FatalInjury"}}</strong></p>  
+        <p><strong>{{localize "YZECORIOLIS.FatalInjury"}}</strong></p>
         {{/if}}
-        <p><strong>{{localize "YZECORIOLIS.InjuryTimeLimitRoll"}} : </strong>{{item.data.timeLimit}}</p>  
-        <p><strong>{{localize "YZECORIOLIS.InjuryHealTimeRoll"}} : </strong>{{item.data.healTime}}</p>  
+        <p><strong>{{localize "YZECORIOLIS.InjuryTimeLimitRoll"}} : </strong>{{item.data.timeLimit}}</p>
+        <p><strong>{{localize "YZECORIOLIS.InjuryHealTimeRoll"}} : </strong>{{item.data.healTime}}</p>
+        {{#if item.data.bonus}}
+        <p><strong>{{localize "YZECORIOLIS.ModifierForRoll"}} : </strong>{{item.data.bonus}}</p>
+        {{/if}}
+        {{#if item.data.hpInjury}}
+        <p><strong>{{localize "YZECORIOLIS.HPInjury"}} : </strong>{{item.data.hpInjury}}</p>
+        {{/if}}
+        {{#if item.data.mpInjury}}
+        <p><strong>{{localize "YZECORIOLIS.MPInjury"}} : </strong>{{item.data.mpInjury}}</p>
+        {{/if}}
     </div>
     {{/if_eq}}
 
@@ -54,7 +66,7 @@
     {{#if_eq item.type 'talent'}}
     <div>
         {{#if item.data.cost}}
-        <p><strong>{{localize "YZECORIOLIS.Cost"}} : </strong>{{item.data.cost}} {{localize "YZECORIOLIS.Birr"}}</p>  
+        <p><strong>{{localize "YZECORIOLIS.Cost"}} : </strong>{{item.data.cost}} {{localize "YZECORIOLIS.Birr"}}</p>
         {{/if}}
         {{#if item.data.hpBonus}}
         <p><strong>{{localize "YZECORIOLIS.HPBonus"}}: </strong>{{item.data.hpBonus}}</p>
@@ -69,23 +81,23 @@
     {{#if_eq item.type 'weapon'}}
     <div>
         {{#if item.data.restricted}}
-        <p><strong>{{localize "YZECORIOLIS.Restricted"}}</strong></p>  
+        <p><strong>{{localize "YZECORIOLIS.Restricted"}}</strong></p>
         {{/if}}
-        <p><strong>{{localize "YZECORIOLIS.TechTier"}} : </strong>{{getTechTierName item.data.techTier}}</p>  
-        <p><strong>{{localize "YZECORIOLIS.Weight"}} : </strong>{{ getWeightName item.data.weight}}</p>  
-        <p><strong>{{localize "YZECORIOLIS.Cost"}} : </strong>{{item.data.cost}} {{localize "YZECORIOLIS.Birr"}}</p>  
+        <p><strong>{{localize "YZECORIOLIS.TechTier"}} : </strong>{{getTechTierName item.data.techTier}}</p>
+        <p><strong>{{localize "YZECORIOLIS.Weight"}} : </strong>{{ getWeightName item.data.weight}}</p>
+        <p><strong>{{localize "YZECORIOLIS.Cost"}} : </strong>{{item.data.cost}} {{localize "YZECORIOLIS.Birr"}}</p>
         <p><strong>{{localize "YZECORIOLIS.Bonus"}}: </strong>{{item.data.bonus}}</p>
         <p><strong>{{localize "YZECORIOLIS.Initiative"}}: </strong>{{item.data.initiative}}</p>
-        <p><strong>{{localize "YZECORIOLIS.Damage"}} : </strong>{{item.data.damage}}</p> 
-        <p><strong>{{localize "YZECORIOLIS.Crit"}} : </strong>{{getWeaponCritDisplay item.data.crit}}</p> 
+        <p><strong>{{localize "YZECORIOLIS.Damage"}} : </strong>{{item.data.damage}}</p>
+        <p><strong>{{localize "YZECORIOLIS.Crit"}} : </strong>{{getWeaponCritDisplay item.data.crit}}</p>
         {{#if item.data.explosive}}
             <p><strong>{{localize "YZECORIOLIS.BlastPower"}} : </strong>{{item.data.blastPower}}</p>
             <p><strong>{{localize "YZECORIOLIS.BlastRadius"}} : </strong>{{item.data.blastRadius}}</p>
         {{else}}
             <p><strong>{{localize "YZECORIOLIS.Range"}} : </strong>{{getRangeName item.data.range}}</p>
             {{#if item.data.automatic}}
-            <p><strong>{{localize "YZECORIOLIS.Automatic"}}</strong></p> 
-            {{/if}}  
+            <p><strong>{{localize "YZECORIOLIS.Automatic"}}</strong></p>
+            {{/if}}
         {{/if}}
     </div>
     {{/if_eq}}


### PR DESCRIPTION
That push adds an option within the critical injuries to reduce the max HP/MP (should be part of the issue #37)

![image](https://user-images.githubusercontent.com/36819852/174396728-f112b1fd-667a-4d91-8d58-f4743b5580b1.png)


Everything works so far.
But I'm unsure with the wording. Especially with the meaning of "reduction" and the number-input.
Right now you will write an positive number to decrease the max HP/MP. Grammatically it seems correct in my eyes but I think it is a matter of interpretation if you would want to write a negative number. :/

<hr>

The 2nd change is that the "modifier" is now an text-input (for critical injuries and gear). Just a number doesn't help in most cases (which skill/attribute???) so now you can describe it accordingly.

<hr>

The 2nd commit just corrects the offset of the boxes in the item-sheets.

<hr>

The 3rd commit changes according to the ticket #169 the style of critical injuries. Till now there were problems if they had an description with more than one row. Now it is in the same style as talents and items.

https://user-images.githubusercontent.com/36819852/174438951-030a9c10-4ca2-4f6b-9f9f-10fa6065fd06.mp4
