### PR TITLE
Fixed swedish translation for 'YZECORIOLIS.Reputation'

### DIFF
--- a/lang/sv.json
+++ b/lang/sv.json
@@ -38,7 +38,7 @@
   "YZECORIOLIS.RollCriticalSucces": "Stor Framgång",
   "YZECORIOLIS.RollFailure": "Misslyckande",
 
-  "YZECORIOLIS.Reputation": "Rykte",
+  "YZECORIOLIS.Reputation": "Anseende",
   "YZECORIOLIS.Icon": "Ikon",
   "YZECORIOLIS.IconLadyOfTears": "Gråterskan",
   "YZECORIOLIS.IconDancer": "Dansaren",


### PR DESCRIPTION
Fixed the swedish translation for Reputation which should be "Anseende".

![image](https://user-images.githubusercontent.com/2678144/182713272-c72939c3-4374-4bde-a875-f10a17ca153e.png)
