### PR TITLE
fix: allow players to roll their own initiative

### DIFF
--- a/module/hooks.js
+++ b/module/hooks.js
@@ -67,16 +67,18 @@ Hooks.on("renderCombatTracker", (app, html, data) => {
       const id = el.dataset.combatantId;
       const combatant = currentCombat.data.combatants.find((c) => c.id === id);
       const initDiv = el.getElementsByClassName("token-initiative")[0];
-      const initiative = combatant.initiative || "";
-      const readOnly = game.user.isGM ? "" : "readonly";
-      initDiv.innerHTML = `<input style="color: white; "type="number" ${readOnly} value="${initiative}">`;
 
-      initDiv.addEventListener("change", async (e) => {
-        const inputElement = e.target;
-        const combatantId = inputElement.closest("[data-combatant-id]").dataset
-          .combatantId;
-        await currentCombat.setInitiative(combatantId, inputElement.value);
-      });
+      if (combatant.initiative != null) {
+        const readOnly = game.user.isGM ? "" : "readonly";
+        initDiv.innerHTML = `<input style="color: white; "type="number" ${readOnly} value="${combatant.initiative}">`;
+
+        initDiv.addEventListener("change", async (e) => {
+          const inputElement = e.target;
+          const combatantId = inputElement.closest("[data-combatant-id]")
+            .dataset.combatantId;
+          await currentCombat.setInitiative(combatantId, inputElement.value);
+        });
+      }
     });
   }
 });


### PR DESCRIPTION
Small modification to not overwrite the default Foundry initiative element in the combat tracker when the combatant doesn't have an initiative score yet, allowing players to roll for their initiative.

<img width="298" alt="Screen Shot 2022-08-15 at 10 28 13 AM" src="https://user-images.githubusercontent.com/408380/184654580-bffd1d25-5396-425f-bfd4-07b4aa0e22fe.png">

<img width="304" alt="Screen Shot 2022-08-15 at 10 28 25 AM" src="https://user-images.githubusercontent.com/408380/184654597-342317d1-6ac5-48f1-b9eb-73a88a82ddf9.png">

