### PR TITLE
Fix for drag macros

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -28,6 +28,7 @@
   "YZECORIOLIS.ErrorsActorHasDuplicateItemsForMacro": "Der von dir ausgewählte Charakter besitzt diese Ausrüstung mehr als ein Mal. Der erste Treffer wird für das Makro verwendet.",
   "YZECORIOLIS.ErrorsActorNotHasItemForMacro": "Der von dir ausgewählte Charakter besitzt keine Ausrüstung mit diesem Namen.",
   "YZECORIOLIS.ErrorsNotOwnedItemForMacro": "Du kannst nur Makros für Ausrüstungen erstellen, die du besitzt.",
+  "YZECORIOLIS.ErrorsNoItemForMacro": "Für dieses Element kannst du kein Makro erstellen. Nur für Waffen, Sprengstoffe und Panzerungen.",
 
   "YZECORIOLIS.PrayToIcons": "Zu den Ikonen beten",
   "YZECORIOLIS.PushedRoll": "Wiederholter Wurf",

--- a/lang/en.json
+++ b/lang/en.json
@@ -28,6 +28,7 @@
   "YZECORIOLIS.ErrorsActorHasDuplicateItemsForMacro": "Your controlled Actor has more than one Item with that name. The first matched item will be chosen.",
   "YZECORIOLIS.ErrorsActorNotHasItemForMacro": "Your controlled Actor does not have an item with that name.",
   "YZECORIOLIS.ErrorsNotOwnedItemForMacro": "You can only create macro buttons for owned items.",
+  "YZECORIOLIS.ErrorsNoItemForMacro": "You can't make an macro for this element. Only for weapons, explosives and armor.",
 
   "YZECORIOLIS.PrayToIcons": "Pray to the Icons",
   "YZECORIOLIS.PushedRoll": "Pushed Roll",

--- a/module/yzecoriolis.js
+++ b/module/yzecoriolis.js
@@ -453,8 +453,10 @@ async function createYzeCoriolisMacro(documentData, slot) {
       game.i18n.localize("YZECORIOLIS.ErrorsNotOwnedItemForMacro")
     );
   const item = await fromUuid(documentData.uuid, false);
-  if (!item) {
-    return;
+  if (!item || (item.type !== "weapon" && item.type !== "armor")) {
+    return ui.notifications.warn(
+      game.i18n.localize("YZECORIOLIS.ErrorsNoItemForMacro")
+    );
   }
   // create the macro command.  Get an existing item macro if it exists.
   // Otherwise create a new one.

--- a/module/yzecoriolis.js
+++ b/module/yzecoriolis.js
@@ -398,7 +398,9 @@ Hooks.once("ready", async function () {
   // wait to register hotbar drop hook on ready so that modules could register earlier if they want to
   Hooks.on("hotbarDrop", (bar, data, slot) => {
     createYzeCoriolisMacro(data, slot);
+    if (data.type === "Item"){
     return false;
+    }
   });
 
   await importShipSheetTutorial();

--- a/templates/sidebar/roll.html
+++ b/templates/sidebar/roll.html
@@ -43,8 +43,8 @@
             {{/if}}
           {{/if_eq}}
           <tr>
-            <td>{{#if_eq rollType 'armor'}}{{localize "YZECORIOLIS.ArmorRating"}}: {{bonus}}{{else}}{{attributeName}}: {{attribute}}{{/if_eq}}</td>
-            <td>{{#if skillName}}{{skillName}}: {{skill}}{{/if}}</td>
+            <td>{{#if_eq rollType 'armor'}}{{localize "YZECORIOLIS.ArmorRating"}}: {{bonus}}</td>{{else}}{{attributeName}}: {{attribute}}</td>
+            <td>{{#if skillName}}{{skillName}}: {{skill}}{{/if}}</td>{{/if_eq}}
           </tr>
           <tr>
             <td>{{localize "YZECORIOLIS.ModifierForRoll"}}: {{modifier}}</td>


### PR DESCRIPTION
Resolves #205

Should fix 3 things:

1. that macros from th macro-folder coulnd't be placed
2. armor-macro-rolls hat an attribute displayed
3. it is no longer possible to create macros for other things than weapons, explosives and armor (because you can't roll an them anyway).