### PR TITLE
Item Modificators

### DIFF
--- a/css/yzecoriolis.css
+++ b/css/yzecoriolis.css
@@ -2728,6 +2728,9 @@
 .yzecoriolis.sheet.item .feature-section .special-feature-header .feature-controls a.feature-create {
   flex: 0 0 100%;
 }
+.yzecoriolis.sheet.item .feature-section .special-feature-header .feature-controls a.itemModifier-create {
+  flex: 0 0 100%;
+}
 .yzecoriolis.sheet.item .feature-section .special-feature-header .feature-name {
   text-align: center;
 }
@@ -2758,6 +2761,7 @@
   flex: 0 0 22px;
   font-size: 12px;
   text-align: center;
+  align-self: center;
   color: #7a7971;
 }
 .yzecoriolis.sheet.item .sheet-tabs {

--- a/lang/de.json
+++ b/lang/de.json
@@ -6,6 +6,7 @@
   "YZECORIOLIS.SheetNotes": "Notizen",
   "YZECORIOLIS.Enabled": "Aktiviert",
   "YZECORIOLIS.Disabled": "Deaktiviert",
+  "YZECORIOLIS.Other": "Sonstiges",
 
   "YZECORIOLIS.HitPoints": "Trefferpunkte",
   "YZECORIOLIS.MindPoints": "Willenskraftpunkte",
@@ -425,5 +426,11 @@
   "YZECORIOLIS.AutomaticFire": "Automatisches Feuer",
   "YZECORIOLIS.AutomaticFireModifier": "Modifikator von -2 auf deinen Angriffswurf",
   "YZECORIOLIS.RollTotal": "Gesamtwurf",
-  "YZECORIOLIS.RollSubstitute": "Verzweiflungswurf (2d6) anstatt"
+  "YZECORIOLIS.RollSubstitute": "Verzweiflungswurf (2d6) anstatt",
+
+  "YZECORIOLIS.ItemModifiers": "Modifikatoren",
+  "YZECORIOLIS.ItemModifierCreate": "Modifikator erstellen",
+  "YZECORIOLIS.ItemModifierDelete": "Modifikator löschen",
+  "YZECORIOLIS.ItemModifierSelect": "Bitte einen Modifikator auswählen.",
+  "YZECORIOLIS.ItemModifierValue": "Wert des Modifikators."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -6,6 +6,7 @@
   "YZECORIOLIS.SheetNotes": "Notes",
   "YZECORIOLIS.Enabled": "Enabled",
   "YZECORIOLIS.Disabled": "Disabled",
+  "YZECORIOLIS.Other": "Other",
 
   "YZECORIOLIS.HitPoints": "Hit Points",
   "YZECORIOLIS.MindPoints": "Mind Points",
@@ -424,5 +425,11 @@
   "YZECORIOLIS.AutomaticFire": "Automatic fire",
   "YZECORIOLIS.AutomaticFireModifier": "-2 modifier to your attack roll",
   "YZECORIOLIS.RollTotal": "Total rolled",
-  "YZECORIOLIS.RollSubstitute": "Desperation roll (2d6) instead of"
+  "YZECORIOLIS.RollSubstitute": "Desperation roll (2d6) instead of",
+
+  "YZECORIOLIS.ItemModifiers": "Modifiers",
+  "YZECORIOLIS.ItemModifierCreate": "Create Modifier",
+  "YZECORIOLIS.ItemModifierDelete": "Delete Modifier",
+  "YZECORIOLIS.ItemModifierSelect": "Please, choose an Modifier.",
+  "YZECORIOLIS.ItemModifierValue": "Value of the Modifier"
 }

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -90,14 +90,25 @@ export class yzecoriolisActor extends Actor {
 
     let hpBonuses = this._prepHPBonuses();
     let mpBonuses = this._prepMPBonuses();
+    let hpModifcations = this._prepHPModifications();
+    let mpModifcations = this._prepMPModifications();
+    let radiationModifcations = this._prepRadiationModifications();
+    let encumbranceModifcations = this._prepEncumbranceModifications();
+    let movementRateModifcations = this._prepMovementRateModifications();
     sysData.hitPoints.max =
       sysData.attributes.strength.value +
       sysData.attributes.agility.value +
-      hpBonuses;
+      hpBonuses + hpModifcations;
     sysData.mindPoints.max =
       sysData.attributes.wits.value +
       sysData.attributes.empathy.value +
-      mpBonuses;
+      mpBonuses + mpModifcations;
+    sysData.radiation.max =
+      sysData.radiation.max +
+      radiationModifcations;
+    sysData.movementRate =
+      sysData.movementRate +
+      movementRateModifcations;
 
     if (sysData.hitPoints.value > sysData.hitPoints.max) {
       sysData.hitPoints.value = sysData.hitPoints.max;
@@ -167,6 +178,81 @@ export class yzecoriolisActor extends Actor {
       }
       const tData = t.system;
       bonus += Number(tData.mpBonus);
+    }
+    return bonus;
+  }
+
+  _prepHPModifications() {
+    // look through items for any HP-Modifications
+    let bonus = 0;
+    for (let t of this.items) {
+      const tData = t.system.itemModifiers;
+      bonus += Number(Object.keys(tData).reduce((counter,x) => {
+        counter += (tData[x].mod === "ItemModifier.HP")
+          ? tData[x].value
+          : 0; return counter;
+        }
+      , 0));
+    }
+    return bonus;
+  }
+
+  _prepMPModifications() {
+    // look through items for any MP-Modifications
+    let bonus = 0;
+    for (let t of this.items) {
+      const tData = t.system.itemModifiers;
+      bonus += Number(Object.keys(tData).reduce((counter,x) => {
+        counter += (tData[x].mod === "ItemModifier.MP")
+          ? tData[x].value
+          : 0; return counter;
+        }
+      , 0));
+    }
+    return bonus;
+  }
+
+  _prepRadiationModifications() {
+    // look through items for any Radiation-Modifications
+    let bonus = 0;
+    for (let t of this.items) {
+      const tData = t.system.itemModifiers;
+      bonus += Number(Object.keys(tData).reduce((counter,x) => {
+        counter += (tData[x].mod === "ItemModifier.Rad")
+          ? tData[x].value
+          : 0; return counter;
+        }
+      , 0));
+    }
+    return bonus;
+  }
+
+  _prepEncumbranceModifications() {
+    // look through items for any Encumbrance-Modifications
+    let bonus = 0;
+    for (let t of this.items) {
+      const tData = t.system.itemModifiers;
+      bonus += Number(Object.keys(tData).reduce((counter,x) => {
+        counter += (tData[x].mod === "ItemModifier.Enc")
+          ? tData[x].value
+          : 0; return counter;
+        }
+      , 0));
+    }
+    return bonus;
+  }
+
+  _prepMovementRateModifications() {
+    // look through items for any MovementRate-Modifications
+    let bonus = 0;
+    for (let t of this.items) {
+      const tData = t.system.itemModifiers;
+      bonus += Number(Object.keys(tData).reduce((counter,x) => {
+        counter += (tData[x].mod === "ItemModifier.MR")
+          ? tData[x].value
+          : 0; return counter;
+        }
+      , 0));
     }
     return bonus;
   }

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -73,11 +73,13 @@ export class yzecoriolisItemSheet extends ItemSheet {
     if (!this.options.editable) return;
 
     // Roll handlers, click handlers, etc. would go here.
-    // Add Inventory Item
+    // Add Inventory Item or Modifier
     html.find(".feature-create").click(this._onFeatureCreate.bind(this));
+    html.find(".itemModifier-create").click(this._onItemModifierCreate.bind(this));
 
-    // // Delete Inventory Item
+    // // Delete Inventory Item or Modifier
     html.find(".feature-delete").click(this._onFeatureDelete.bind(this));
+    html.find(".itemModifier-delete").click(this._onItemModifierDelete.bind(this));
   }
 
   _onFeatureCreate(event) {
@@ -105,5 +107,32 @@ export class yzecoriolisItemSheet extends ItemSheet {
   async _setSpecialFeatures(features) {
     await this.object.update({ "system.special": null }, { render: false });
     await this.object.update({ "system.special": features });
+  }
+
+  _onItemModifierCreate(event) {
+    event.preventDefault();
+    const name = "";
+    let itemModifiers = {};
+    if (this.object.system.itemModifiers) {
+      itemModifiers= foundry.utils.deepClone(this.object.system.itemModifiers);
+    }
+    let key = getID();
+    itemModifiers["si" + key] = name;
+    return this.object.update({ "system.itemModifiers": itemModifiers });
+  }
+
+  _onItemModifierDelete(event) {
+    const li = $(event.currentTarget).parents(".special-feature");
+    let itemModifiers = foundry.utils.deepClone(this.object.system.itemModifiers);
+    let targetKey = li.data("itemId");
+    delete itemModifiers[targetKey];
+    li.slideUp(200, async () => {
+      await this._setItemModifiers(itemModifiers);
+    });
+  }
+
+  async _setItemModifiers(itemModifiers) {
+    await this.object.update({ "system.itemModifiers": null }, { render: false });
+    await this.object.update({ "system.itemModifiers": itemModifiers });
   }
 }

--- a/module/templates.js
+++ b/module/templates.js
@@ -17,6 +17,8 @@ export const preloadHandlerbarsTemplates = async function () {
     "systems/yzecoriolis/templates/actor/parts/ship-logbooks.html",
     // dialog templates
     "systems/yzecoriolis/templates/dialog/automatic-fire.html",
+    // partial item templates
+    "systems/yzecoriolis/templates/item/modifiers.html",
   ];
 
   return loadTemplates(templatePaths);

--- a/template.json
+++ b/template.json
@@ -268,7 +268,8 @@
     ],
     "templates": {
       "base": {
-        "description": ""
+        "description": "",
+        "itemModifiers": {}
       },
       "gear": {
         "description": "",
@@ -277,7 +278,8 @@
         "cost": 0,
         "quantity": 1,
         "restricted": false,
-        "equipped": false
+        "equipped": false,
+        "itemModifiers": {}
       }
     },
     "gear": {

--- a/templates/item/armor-sheet.html
+++ b/templates/item/armor-sheet.html
@@ -44,14 +44,17 @@
                     </select>
                 </div>
 
+
                 <div class="resource numeric-input flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.ExtraFeatures"}}</label>
                     <input type="number" min="0" name="system.extraFeatures" value="{{system.extraFeatures}}"
                         data-dtype="Number" />
                 </div>
 
+
             </div>
         </div>
+        {{> systems/yzecoriolis/templates/item/modifiers.html }}
         <div class="feature-section flexrow">
             <ol>
                 <li class="special-feature-header flexrow">

--- a/templates/item/gear-sheet.html
+++ b/templates/item/gear-sheet.html
@@ -29,15 +29,12 @@
                     <input type="checkbox" name="system.restricted" data-dtype="Boolean" {{checked system.restricted}} />
                 </div>
                 <div class="resource flexrow">
-                    <label class="resource-label">{{localize "YZECORIOLIS.Bonus"}}</label>
-                    <input type="text" name="system.bonus" value="{{system.bonus}}" data-dtype="Number" />
-                </div>
-                <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.MoneyCost"}}</label>
                     <input type="text" name="system.cost" value="{{system.cost}}" data-dtype="Number" />
                 </div>
             </div>
         </div>
+        {{> systems/yzecoriolis/templates/item/modifiers.html }}
     </header>
 
     {{!-- Sheet Tab Navigation --}}

--- a/templates/item/injury-sheet.html
+++ b/templates/item/injury-sheet.html
@@ -19,12 +19,8 @@
                 <input type="text" name="system.healTime" value="{{system.healTime}}"
                     data-dtype="String" />
             </div>
-            <div class="resource numeric-input flexrow">
-                <label class="resource-label">{{localize "YZECORIOLIS.ModifierForRoll"}}</label>
-                <input type="number" min="0" name="system.bonus" value="{{system.bonus}}"
-                    data-dtype="Number" />
-            </div>
         </div>
+        {{> systems/yzecoriolis/templates/item/modifiers.html }}
     </header>
 
     {{!-- Sheet Tab Navigation --}}

--- a/templates/item/modifiers.html
+++ b/templates/item/modifiers.html
@@ -1,0 +1,62 @@
+<div class="feature-section flexrow">
+            <ol>
+                <li class="special-feature-header flexrow">
+                    <h3 class="feature-name flexrow">{{localize "YZECORIOLIS.ItemModifiers"}}</h3>
+                    <div class="feature-controls">
+                        <a class="feature-control itemModifier-create" title='{{localize "YZECORIOLIS.ItemModifierCreate"}}'>
+                            <i class="fas fa-plus"></i> {{localize "YZECORIOLIS.Add"}}
+                        </a>
+                    </div>
+                </li>
+                {{#each system.itemModifiers as |itemmod id|}}
+                <li class="special-feature flexrow"  data-item-id="{{id}}">
+                    <div class="feature-name">
+                        <select name="system.itemModifiers.{{id}}.mod">
+                            {{#select itemmod.mod}}
+                            <option value="ItemModifier.None" disabled  selected>{{localize "YZECORIOLIS.ItemModifierSelect"}}</option>
+                            <optgroup label="{{localize "YZECORIOLIS.Attributes"}}">
+                              <option value="ItemModifier.AttrStrength">{{localize "YZECORIOLIS.AttrStrength"}}</option>
+                              <option value="ItemModifier.AttrAgility">{{localize "YZECORIOLIS.AttrAgility"}}</option>
+                              <option value="ItemModifier.AttrWits">{{localize "YZECORIOLIS.AttrWits"}}</option>
+                              <option value="ItemModifier.AttrEmpathy">{{localize "YZECORIOLIS.AttrEmpathy"}}</option>
+                            </optgroup>
+                            <optgroup label="{{localize "YZECORIOLIS.SkillCatGeneral"}}">
+                              <option value="ItemModifier.SkillDex">{{localize "YZECORIOLIS.SkillDexterity"}}</option>
+                              <option value="ItemModifier.SkillForce">{{localize "YZECORIOLIS.SkillForce"}}</option>
+                              <option value="ItemModifier.SkillInf">{{localize "YZECORIOLIS.SkillInfiltration"}}</option>
+                              <option value="ItemModifier.SkillMan">{{localize "YZECORIOLIS.SkillManipulation"}}</option>
+                              <option value="ItemModifier.SkillMelee">{{localize "YZECORIOLIS.SkillMeleeCombat"}}</option>
+                              <option value="ItemModifier.SkillObs">{{localize "YZECORIOLIS.SkillObservation"}}</option>
+                              <option value="ItemModifier.SkillRange">{{localize "YZECORIOLIS.SkillRangedCombat"}}</option>
+                              <option value="ItemModifier.SkillSurv">{{localize "YZECORIOLIS.SkillSurvival"}}</option>
+                            </optgroup>
+                            <optgroup label="{{localize "YZECORIOLIS.SkillCatAdvanced"}}">
+                              <option value="ItemModifier.SkillCom">{{localize "YZECORIOLIS.SkillCommand"}}</option>
+                              <option value="ItemModifier.SkillCult">{{localize "YZECORIOLIS.SkillCulture"}}</option>
+                              <option value="ItemModifier.SkillData">{{localize "YZECORIOLIS.SkillDataDjinn"}}</option>
+                              <option value="ItemModifier.SkillMedi">{{localize "YZECORIOLIS.SkillMedicurgy"}}</option>
+                              <option value="ItemModifier.SkillMys">{{localize "YZECORIOLIS.SkillMysticPowers"}}</option>
+                              <option value="ItemModifier.SkillPil">{{localize "YZECORIOLIS.SkillPilot"}}</option>
+                              <option value="ItemModifier.SkillSci">{{localize "YZECORIOLIS.SkillScience"}}</option>
+                              <option value="ItemModifier.SkillTech">{{localize "YZECORIOLIS.SkillTechnology"}}</option>
+                            </optgroup>
+                            <optgroup label="{{localize "YZECORIOLIS.Other"}}">
+                              <option value="ItemModifier.HP">{{localize "YZECORIOLIS.HitPoints"}}</option>
+                              <option value="ItemModifier.MP">{{localize "YZECORIOLIS.MindPoints"}}</option>
+                              <option value="ItemModifier.Rad">{{localize "YZECORIOLIS.Radiation"}}</option>
+                              <option value="ItemModifier.Enc">{{localize "YZECORIOLIS.Encumbrance"}}</option>
+                              <option value="ItemModifier.MR">{{localize "YZECORIOLIS.MovementRate"}}</option>
+                            </optgroup>
+                            {{/select}}
+                        </select>
+                    </div>
+                    <div style="flex: 1 1 10%;" title="{{localize "YZECORIOLIS.ItemModifierValue"}}">
+                        <input name="system.itemModifiers.{{id}}.value" type="number" value="{{#if itemmod.value}}{{itemmod.value}}{{else}}0{{/if}}" style="text-align: center;"/>
+                    </div>
+                    <div class="feature-controls">
+                      <a class="feature-control itemModifier-delete" title="{{localize 'YZECORIOLIS.ItemModifierDelete'}}" data-item-id="{{id}}"><i class="fas fa-trash"></i></a>
+                    </div>
+                </li>
+                {{/each}}
+            </ol>
+</div>

--- a/templates/item/talent-sheet.html
+++ b/templates/item/talent-sheet.html
@@ -49,6 +49,7 @@
                 {{/talentHasCost}}
             </div>
         </div>
+        {{> systems/yzecoriolis/templates/item/modifiers.html }}
     </header>
 
     {{!-- Sheet Tab Navigation --}}

--- a/templates/item/weapon-sheet.html
+++ b/templates/item/weapon-sheet.html
@@ -119,6 +119,7 @@
 
             </div>
         </div>
+        {{> systems/yzecoriolis/templates/item/modifiers.html }}
         <div class="feature-section flexrow">
             <ol>
                 <li class="special-feature-header flexrow">


### PR DESCRIPTION
Resolves #160, resolves #37 

This adds the option for modifiers on items (critical injuries, talents, gear, weapons, armor).
It is inspired by the [Forbidden Lands](https://github.com/fvtt-fria-ligan/forbidden-lands-foundry-vtt)-Repo.

![image](https://user-images.githubusercontent.com/36819852/199265744-5258e769-58ab-4bd3-8cd7-63c4294496b9.png) 
![image](https://user-images.githubusercontent.com/36819852/199268165-e6546d66-68ea-41d0-9ebb-06544736f6de.png)
![image](https://user-images.githubusercontent.com/36819852/199458454-fd6ca8fe-27bc-49f5-85be-82f5c7c781e3.png)


### **To-Do**
- [X] basic integration
- [X] calculation for Hit Points
- - [ ] replace / delete Talent HP Bonus
- [X] calculation for Mind Points
- - [ ] replace / delete Talent MP Bonus
- [X] calculation for Radiation
- [ ] calculation for Movement Rate (is implemented but should be faulty!)
- [ ] calculation für Encumbrance (has no value in the sheet right now - it is always just calculated)
- [ ] option for calculation in rolls (attributes and skills)
- - [ ] adding modifiers to advanced-roll infos
- [ ] CSS / .less stuff (right now it is just replaced in the CSS and works on the Special Feature-parts, should it be on his own?)
- [ ] adding modifiers to item-posts (to chat)