### PR TITLE
fix translations for modules like Item Piles

### DIFF
--- a/module/config.js
+++ b/module/config.js
@@ -101,6 +101,19 @@ YZECORIOLIS.itemTypes = {
   talent: "YZECORIOLIS.Talent",
   injury: "YZECORIOLIS.CriticalInjury",
 };
+ // needed for some modules like Item Piles
+CONFIG.Item.typeLabels = {
+  weapon: "YZECORIOLIS.Weapon",
+  armor: "YZECORIOLIS.Armor",
+  gear: "YZECORIOLIS.Gear",
+  talent: "YZECORIOLIS.Talent",
+  injury: "YZECORIOLIS.CriticalInjury",
+  shipProblem: "YZECORIOLIS.ShipProblem",
+  shipModule: "YZECORIOLIS.Modules",
+  shipFeature: "YZECORIOLIS.ShipFeature",
+  shipCriticalDamage: "YZECORIOLIS.ShipCriticalDamage",
+  shipLogbook: "YZECORIOLIS.ShipLogbook",
+};
 
 // Talents
 


### PR DESCRIPTION
Some Foundry-modules uses the Item.typeLabels as base for their translations.

This fixxes the ticket from Item Piles: https://github.com/fantasycalendar/FoundryVTT-ItemPiles/issues/210