### PR TITLE
[DRAFT] Add Item Modifiers

### DIFF
--- a/css/yzecoriolis.css
+++ b/css/yzecoriolis.css
@@ -2759,6 +2759,9 @@
 .yzecoriolis.sheet.item .feature-section .special-feature-header .feature-controls a.feature-create {
   flex: 0 0 100%;
 }
+.yzecoriolis.sheet.item .feature-section .special-feature-header .feature-controls a.itemModifier-create {
+  flex: 0 0 100%;
+}
 .yzecoriolis.sheet.item .feature-section .special-feature-header .feature-name {
   text-align: center;
 }
@@ -2789,6 +2792,7 @@
   flex: 0 0 22px;
   font-size: 12px;
   text-align: center;
+  align-self: center;
   color: #7a7971;
 }
 .yzecoriolis.sheet.item .sheet-tabs {

--- a/lang/de.json
+++ b/lang/de.json
@@ -6,7 +6,7 @@
   "YZECORIOLIS.SheetNotes": "Notizen",
   "YZECORIOLIS.Enabled": "Aktiviert",
   "YZECORIOLIS.Disabled": "Deaktiviert",
-  "YZECORIOLIS.Other": "Sonstige(s)",
+  "YZECORIOLIS.Other": "Sonstiges",
 
   "YZECORIOLIS.HitPoints": "Trefferpunkte",
   "YZECORIOLIS.MindPoints": "Willenskraftpunkte",

--- a/lang/de.json
+++ b/lang/de.json
@@ -6,6 +6,7 @@
   "YZECORIOLIS.SheetNotes": "Notizen",
   "YZECORIOLIS.Enabled": "Aktiviert",
   "YZECORIOLIS.Disabled": "Deaktiviert",
+  "YZECORIOLIS.Other": "Sonstige(s)",
 
   "YZECORIOLIS.HitPoints": "Trefferpunkte",
   "YZECORIOLIS.MindPoints": "Willenskraftpunkte",
@@ -425,5 +426,11 @@
   "YZECORIOLIS.AutomaticFire": "Automatisches Feuer",
   "YZECORIOLIS.AutomaticFireModifier": "Modifikator von -2 auf deinen Angriffswurf",
   "YZECORIOLIS.RollTotal": "Gesamtwurf",
-  "YZECORIOLIS.RollSubstitute": "Verzweiflungswurf (2d6) anstatt"
+  "YZECORIOLIS.RollSubstitute": "Verzweiflungswurf (2d6) anstatt",
+
+  "YZECORIOLIS.ItemModifiers": "Modifikatoren",
+  "YZECORIOLIS.ItemModifierCreate": "Neuer Modifikator",
+  "YZECORIOLIS.ItemModifierDelete": "Modifikator löschen",
+  "YZECORIOLIS.ItemModifierSelect": "Bitte wähle einen Modifikator aus.",
+  "YZECORIOLIS.ItemModifierValue": "Wert des Modifikators"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -6,6 +6,7 @@
   "YZECORIOLIS.SheetNotes": "Notes",
   "YZECORIOLIS.Enabled": "Enabled",
   "YZECORIOLIS.Disabled": "Disabled",
+  "YZECORIOLIS.Other": "Other",
 
   "YZECORIOLIS.HitPoints": "Hit Points",
   "YZECORIOLIS.MindPoints": "Mind Points",
@@ -425,5 +426,11 @@
   "YZECORIOLIS.AutomaticFire": "Automatic fire",
   "YZECORIOLIS.AutomaticFireModifier": "-2 modifier to your attack roll",
   "YZECORIOLIS.RollTotal": "Total rolled",
-  "YZECORIOLIS.RollSubstitute": "Desperation roll (2d6) instead of"
+  "YZECORIOLIS.RollSubstitute": "Desperation roll (2d6) instead of",
+
+  "YZECORIOLIS.ItemModifiers": "Modifiers",
+  "YZECORIOLIS.ItemModifierCreate": "Create Modifier",
+  "YZECORIOLIS.ItemModifierDelete": "Delete Modifier",
+  "YZECORIOLIS.ItemModifierSelect": "Please, choose an Modifier.",
+  "YZECORIOLIS.ItemModifierValue": "Value of the Modifier"
 }

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -336,7 +336,7 @@ export class yzecoriolisActorSheet extends ActorSheet {
     // for display purposes we'll halve everything so that encumbrance makes
     // sense to users that are familiar with the rules.
     let enc = {
-      max: strengthValue / 2,
+      max: (strengthValue / 2) + this.actor.system.encumbranceMods,
       value: totalWeight / 2,
     };
     let pct = (enc.value / enc.max) * 100;
@@ -344,7 +344,11 @@ export class yzecoriolisActorSheet extends ActorSheet {
       pct = 0;
     }
     enc.percentage = Math.min(pct, 100);
-    enc.encumbered = pct > 100;
+    if (pct > 100 || pct < 0) {
+      enc.encumbered = true;
+    } else {
+      enc.encumbered = false;
+    }
     return enc;
   }
 
@@ -516,7 +520,9 @@ export class yzecoriolisActorSheet extends ActorSheet {
       range: item?.range,
       crit: item?.crit?.numericValue,
       critText: item?.crit?.customValue,
-      features: item?.special ? Object.values(item.special).join(", ") : "",
+      features: item?.special
+        ? Object.values(item.special).join(", ")
+        : "",
     };
     const chatOptions = this.actor._prepareChatRollOptions(
       "systems/yzecoriolis/templates/sidebar/roll.html",

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -158,7 +158,7 @@ export class yzecoriolisActor extends Actor {
     for (let t of this.items) {
       const tData = t.system.itemModifiers;
       bonus += Number(Object.keys(tData).reduce((counter,x) => {
-        counter += (tData[x].mod === "itemModifierHP")
+        counter += (tData[x].mod === "itemModifierHP" && (t.type === 'injury' || t.type === 'talent' || t.system.equipped === true))
           ? tData[x].value
           : 0;
           return counter;
@@ -174,7 +174,7 @@ export class yzecoriolisActor extends Actor {
     for (let t of this.items) {
       const tData = t.system.itemModifiers;
       bonus += Number(Object.keys(tData).reduce((counter,x) => {
-        counter += (tData[x].mod === "itemModifierMP")
+        counter += (tData[x].mod === "itemModifierMP" && (t.type === 'injury' || t.type === 'talent' || t.system.equipped === true))
           ? tData[x].value
           : 0;
           return counter;
@@ -190,7 +190,7 @@ export class yzecoriolisActor extends Actor {
     for (let t of this.items) {
       const tData = t.system.itemModifiers;
       bonus += Number(Object.keys(tData).reduce((counter,x) => {
-        counter += (tData[x].mod === "itemModifierRad")
+        counter += (tData[x].mod === "itemModifierRad" && (t.type === 'injury' || t.type === 'talent' || t.system.equipped === true))
           ? tData[x].value
           : 0;
           return counter;
@@ -206,7 +206,7 @@ export class yzecoriolisActor extends Actor {
     for (let t of this.items) {
       const tData = t.system.itemModifiers;
       bonus += Number(Object.keys(tData).reduce((counter,x) => {
-        counter += (tData[x].mod === "itemModifierEnc")
+        counter += (tData[x].mod === "itemModifierEnc" && (t.type === 'injury' || t.type === 'talent' || t.system.equipped === true))
           ? tData[x].value
           : 0;
           return counter;
@@ -222,7 +222,7 @@ export class yzecoriolisActor extends Actor {
     for (let t of this.items) {
       const tData = t.system.itemModifiers;
       bonus += Number(Object.keys(tData).reduce((counter,x) => {
-        counter += (tData[x].mod === "itemModifierMR")
+        counter += (tData[x].mod === "itemModifierMR" && (t.type === 'injury' || t.type === 'talent' || t.system.equipped === true))
           ? tData[x].value
           : 0;
           return counter;

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -158,7 +158,7 @@ export class yzecoriolisActor extends Actor {
     for (let t of this.items) {
       const tData = t.system.itemModifiers;
       bonus += Number(Object.keys(tData).reduce((counter,x) => {
-        counter += (tData[x].mod === "ItemModifier.HP")
+        counter += (tData[x].mod === "itemModifierHP")
           ? tData[x].value
           : 0;
           return counter;
@@ -174,7 +174,7 @@ export class yzecoriolisActor extends Actor {
     for (let t of this.items) {
       const tData = t.system.itemModifiers;
       bonus += Number(Object.keys(tData).reduce((counter,x) => {
-        counter += (tData[x].mod === "ItemModifier.MP")
+        counter += (tData[x].mod === "itemModifierMP")
           ? tData[x].value
           : 0;
           return counter;
@@ -190,7 +190,7 @@ export class yzecoriolisActor extends Actor {
     for (let t of this.items) {
       const tData = t.system.itemModifiers;
       bonus += Number(Object.keys(tData).reduce((counter,x) => {
-        counter += (tData[x].mod === "ItemModifier.Rad")
+        counter += (tData[x].mod === "itemModifierRad")
           ? tData[x].value
           : 0;
           return counter;
@@ -206,7 +206,7 @@ export class yzecoriolisActor extends Actor {
     for (let t of this.items) {
       const tData = t.system.itemModifiers;
       bonus += Number(Object.keys(tData).reduce((counter,x) => {
-        counter += (tData[x].mod === "ItemModifier.Enc")
+        counter += (tData[x].mod === "itemModifierEnc")
           ? tData[x].value
           : 0;
           return counter;
@@ -222,7 +222,7 @@ export class yzecoriolisActor extends Actor {
     for (let t of this.items) {
       const tData = t.system.itemModifiers;
       bonus += Number(Object.keys(tData).reduce((counter,x) => {
-        counter += (tData[x].mod === "ItemModifier.MR")
+        counter += (tData[x].mod === "itemModifierMR")
           ? tData[x].value
           : 0;
           return counter;

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -88,8 +88,6 @@ export class yzecoriolisActor extends Actor {
       });
     }
 
-    let hpBonuses = this._prepHPBonuses();
-    let mpBonuses = this._prepMPBonuses();
     let hpModifcations = this._prepHPModifications();
     let mpModifcations = this._prepMPModifications();
     let radiationModifcations = this._prepRadiationModifications();
@@ -97,11 +95,9 @@ export class yzecoriolisActor extends Actor {
     let movementRateModifcations = this._prepMovementRateModifications();
     sysData.hitPoints.max = sysData.attributes.strength.value
       + sysData.attributes.agility.value
-      + hpBonuses
       + hpModifcations;
     sysData.mindPoints.max = sysData.attributes.wits.value
       + sysData.attributes.empathy.value
-      + mpBonuses
       + mpModifcations;
     sysData.radiation.max = sysData.radiation.max
       + radiationModifcations;
@@ -154,32 +150,6 @@ export class yzecoriolisActor extends Actor {
     }
 
     return chatOptions;
-  }
-
-  _prepHPBonuses() {
-    // look through talents for any HPBonuses
-    let bonus = 0;
-    for (let t of this.items) {
-      if (t.type !== "talent") {
-        continue;
-      }
-      const tData = t.system;
-      bonus += Number(tData.hpBonus);
-    }
-    return bonus;
-  }
-
-  _prepMPBonuses() {
-    // look through talents for any MPBonuses
-    let bonus = 0;
-    for (let t of this.items) {
-      if (t.type !== "talent") {
-        continue;
-      }
-      const tData = t.system;
-      bonus += Number(tData.mpBonus);
-    }
-    return bonus;
   }
 
   _prepHPModifications() {

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -90,14 +90,28 @@ export class yzecoriolisActor extends Actor {
 
     let hpBonuses = this._prepHPBonuses();
     let mpBonuses = this._prepMPBonuses();
+    let hpModifcations = this._prepHPModifications();
+    let mpModifcations = this._prepMPModifications();
+    let radiationModifcations = this._prepRadiationModifications();
+    let encumbranceModifcations = this._prepEncumbranceModifications();
+    let movementRateModifcations = this._prepMovementRateModifications();
     sysData.hitPoints.max =
-      sysData.attributes.strength.value +
-      sysData.attributes.agility.value +
-      hpBonuses;
+      sysData.attributes.strength.value
+      + sysData.attributes.agility.value
+      + hpBonuses
+      + hpModifcations;
     sysData.mindPoints.max =
-      sysData.attributes.wits.value +
-      sysData.attributes.empathy.value +
-      mpBonuses;
+      sysData.attributes.wits.value
+      + sysData.attributes.empathy.value
+      + mpBonuses
+      + mpModifcations;
+    sysData.radiation.max =
+      sysData.radiation.max
+      + radiationModifcations;
+    sysData.movementRateMods =
+      movementRateModifcations;
+    sysData.encumbranceMods =
+      encumbranceModifcations;
 
     if (sysData.hitPoints.value > sysData.hitPoints.max) {
       sysData.hitPoints.value = sysData.hitPoints.max;
@@ -169,6 +183,86 @@ export class yzecoriolisActor extends Actor {
       }
       const tData = t.system;
       bonus += Number(tData.mpBonus);
+    }
+    return bonus;
+  }
+
+  _prepHPModifications() {
+    // look through items for any HP-Modifications
+    let bonus = 0;
+    for (let t of this.items) {
+      const tData = t.system.itemModifiers;
+      bonus += Number(Object.keys(tData).reduce((counter,x) => {
+        counter += (tData[x].mod === "ItemModifier.HP")
+          ? tData[x].value
+          : 0;
+          return counter;
+        }
+      , 0));
+    }
+    return bonus;
+  }
+
+  _prepMPModifications() {
+    // look through items for any MP-Modifications
+    let bonus = 0;
+    for (let t of this.items) {
+      const tData = t.system.itemModifiers;
+      bonus += Number(Object.keys(tData).reduce((counter,x) => {
+        counter += (tData[x].mod === "ItemModifier.MP")
+          ? tData[x].value
+          : 0;
+          return counter;
+        }
+      , 0));
+    }
+    return bonus;
+  }
+
+  _prepRadiationModifications() {
+    // look through items for any Radiation-Modifications
+    let bonus = 0;
+    for (let t of this.items) {
+      const tData = t.system.itemModifiers;
+      bonus += Number(Object.keys(tData).reduce((counter,x) => {
+        counter += (tData[x].mod === "ItemModifier.Rad")
+          ? tData[x].value
+          : 0;
+          return counter;
+        }
+      , 0));
+    }
+    return bonus;
+  }
+
+  _prepEncumbranceModifications() {
+    // look through items for any Encumbrance-Modifications
+    let bonus = 0;
+    for (let t of this.items) {
+      const tData = t.system.itemModifiers;
+      bonus += Number(Object.keys(tData).reduce((counter,x) => {
+        counter += (tData[x].mod === "ItemModifier.Enc")
+          ? tData[x].value
+          : 0;
+          return counter;
+        }
+      , 0));
+    }
+    return bonus;
+  }
+
+  _prepMovementRateModifications() {
+    // look through items for any MovementRate-Modifications
+    let bonus = 0;
+    for (let t of this.items) {
+      const tData = t.system.itemModifiers;
+      bonus += Number(Object.keys(tData).reduce((counter,x) => {
+        counter += (tData[x].mod === "ItemModifier.MR")
+          ? tData[x].value
+          : 0;
+          return counter;
+        }
+      , 0));
     }
     return bonus;
   }

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -95,23 +95,18 @@ export class yzecoriolisActor extends Actor {
     let radiationModifcations = this._prepRadiationModifications();
     let encumbranceModifcations = this._prepEncumbranceModifications();
     let movementRateModifcations = this._prepMovementRateModifications();
-    sysData.hitPoints.max =
-      sysData.attributes.strength.value
+    sysData.hitPoints.max = sysData.attributes.strength.value
       + sysData.attributes.agility.value
       + hpBonuses
       + hpModifcations;
-    sysData.mindPoints.max =
-      sysData.attributes.wits.value
+    sysData.mindPoints.max = sysData.attributes.wits.value
       + sysData.attributes.empathy.value
       + mpBonuses
       + mpModifcations;
-    sysData.radiation.max =
-      sysData.radiation.max
+    sysData.radiation.max = sysData.radiation.max
       + radiationModifcations;
-    sysData.movementRateMods =
-      movementRateModifcations;
-    sysData.encumbranceMods =
-      encumbranceModifcations;
+    sysData.movementRateMods = movementRateModifcations;
+    sysData.encumbranceMods = encumbranceModifcations;
 
     if (sysData.hitPoints.value > sysData.hitPoints.max) {
       sysData.hitPoints.value = sysData.hitPoints.max;

--- a/module/config.js
+++ b/module/config.js
@@ -101,7 +101,34 @@ YZECORIOLIS.itemTypes = {
   talent: "YZECORIOLIS.Talent",
   injury: "YZECORIOLIS.CriticalInjury",
 };
- // needed for some modules like Item Piles
+YZECORIOLIS.itemModifierNames = {
+  itemModifierAttrStrength: "YZECORIOLIS.AttrStrength",
+  itemModifierAttrAgility: "YZECORIOLIS.AttrAgility",
+  itemModifierAttrWits: "YZECORIOLIS.AttrWits",
+  itemModifierAttrEmpathy: "YZECORIOLIS.AttrEmpathy",
+  itemModifierSkillDex: "YZECORIOLIS.SkillDexterity",
+  itemModifierSkillForce: "YZECORIOLIS.SkillForce",
+  itemModifierSkillInf: "YZECORIOLIS.SkillInfiltration",
+  itemModifierSkillMan: "YZECORIOLIS.SkillManipulation",
+  itemModifierSkillMelee: "YZECORIOLIS.SkillMeleeCombat",
+  itemModifierSkillObs: "YZECORIOLIS.SkillObservation",
+  itemModifierSkillRange: "YZECORIOLIS.SkillRangedCombat",
+  itemModifierSkillSurv: "YZECORIOLIS.SkillSurvival",
+  itemModifierSkillCom: "YZECORIOLIS.SkillCommand",
+  itemModifierSkillCult: "YZECORIOLIS.SkillCulture",
+  itemModifierSkillData: "YZECORIOLIS.SkillDataDjinn",
+  itemModifierSkillMedi: "YZECORIOLIS.SkillMedicurgy",
+  itemModifierSkillMys: "YZECORIOLIS.SkillMysticPowers",
+  itemModifierSkillPil: "YZECORIOLIS.SkillPilot",
+  itemModifierSkillSci: "YZECORIOLIS.SkillScience",
+  itemModifierSkillTech: "YZECORIOLIS.SkillTechnology",
+  itemModifierHP: "YZECORIOLIS.HitPoints",
+  itemModifierMP: "YZECORIOLIS.MindPoints",
+  itemModifierRad: "YZECORIOLIS.Radiation",
+  itemModifierEnc: "YZECORIOLIS.Encumbrance",
+  itemModifierMR: "YZECORIOLIS.MovementRate",
+};
+// needed for some modules like Item Piles
 CONFIG.Item.typeLabels = {
   weapon: "YZECORIOLIS.Weapon",
   armor: "YZECORIOLIS.Armor",

--- a/module/coriolis-roll.js
+++ b/module/coriolis-roll.js
@@ -21,11 +21,10 @@ export async function coriolisModifierDialog(
 
   let content =
     (automaticWeapon
-      ? await renderTemplate(
-          "systems/yzecoriolis/templates/dialog/automatic-fire.html"
-        )
-      : "") +
-    `<p>${game.i18n.localize("YZECORIOLIS.ModifierForRollQuestion")}</p>`;
+      ? await renderTemplate("systems/yzecoriolis/templates/dialog/automatic-fire.html")
+      : ""
+    )
+    + `<h3>${game.i18n.localize("YZECORIOLIS.ModifierForRollQuestion")}</h3>`;
   let d = new Dialog({
     title: game.i18n.localize("YZECORIOLIS.ModifierForRoll"),
     content: content,
@@ -128,7 +127,9 @@ export async function coriolisModifierDialog(
       });
     },
     close: () => {},
-  });
+  },
+  { height: "max-content!important" }
+  );
   d.render(true);
 }
 

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -114,7 +114,7 @@ export class yzecoriolisItemSheet extends ItemSheet {
     const name = "";
     let itemModifiers = {};
     if (this.object.system.itemModifiers) {
-      itemModifiers= foundry.utils.deepClone(this.object.system.itemModifiers);
+      itemModifiers = foundry.utils.deepClone(this.object.system.itemModifiers);
     }
     let key = getID();
     itemModifiers["si" + key] = name;

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -73,11 +73,13 @@ export class yzecoriolisItemSheet extends ItemSheet {
     if (!this.options.editable) return;
 
     // Roll handlers, click handlers, etc. would go here.
-    // Add Inventory Item
+    // Add Inventory Item or Modifier
     html.find(".feature-create").click(this._onFeatureCreate.bind(this));
+    html.find(".itemModifier-create").click(this._onItemModifierCreate.bind(this));
 
-    // // Delete Inventory Item
+    // // Delete Inventory Item or Modifier
     html.find(".feature-delete").click(this._onFeatureDelete.bind(this));
+    html.find(".itemModifier-delete").click(this._onItemModifierDelete.bind(this));
   }
 
   _onFeatureCreate(event) {
@@ -105,5 +107,32 @@ export class yzecoriolisItemSheet extends ItemSheet {
   async _setSpecialFeatures(features) {
     await this.object.update({ "system.special": null }, { render: false });
     await this.object.update({ "system.special": features });
+  }
+
+  _onItemModifierCreate(event) {
+    event.preventDefault();
+    const name = "";
+    let itemModifiers = {};
+    if (this.object.system.itemModifiers) {
+      itemModifiers= foundry.utils.deepClone(this.object.system.itemModifiers);
+    }
+    let key = getID();
+    itemModifiers["si" + key] = name;
+    return this.object.update({ "system.itemModifiers": itemModifiers });
+  }
+
+  _onItemModifierDelete(event) {
+    const li = $(event.currentTarget).parents(".special-feature");
+    let itemModifiers = foundry.utils.deepClone(this.object.system.itemModifiers);
+    let targetKey = li.data("itemId");
+    delete itemModifiers[targetKey];
+    li.slideUp(200, async () => {
+      await this._setItemModifiers(itemModifiers);
+    });
+  }
+
+  async _setItemModifiers(itemModifiers) {
+    await this.object.update({ "system.itemModifiers": null }, { render: false });
+    await this.object.update({ "system.itemModifiers": itemModifiers });
   }
 }

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -116,6 +116,9 @@ export class yzecoriolisItem extends Item {
     const templateData = {
       item: foundry.utils.deepClone(this),
       icon: imgPath,
+      itemModifiers: this.system.itemModifiers
+        ? Object.values(this.system.itemModifiers)
+        : "",
     };
     const html = await renderTemplate(
       `systems/yzecoriolis/templates/sidebar/item.html`,

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -1,4 +1,5 @@
 import { coriolisRoll, coriolisModifierDialog } from "../coriolis-roll.js";
+import { migrateTalentBonus } from "../migration.js";
 /**
  * Extend the basic Item with some very simple modifications.
  * @extends {Item}
@@ -20,6 +21,9 @@ export class yzecoriolisItem extends Item {
   // eslint-disable-next-line no-unused-vars
   _prepareTalentData(itemData) {
     // TODO: prep talent data
+
+    // Migrate HP & MP-Bonus to Modifiers
+    migrateTalentBonus(itemData);
   }
 
   async _preCreate(initData, options, user) {

--- a/module/migration.js
+++ b/module/migration.js
@@ -329,13 +329,13 @@ export const migrateTalentBonus = function(itemData) {
   if (itemData.system.hpBonus) {
     let keyHpMod = getID();
     let nameHpMod = ["si" + keyHpMod];
-    itemData.update({"system.itemModifiers": {nameHpMod: {"mod": "ItemModifier.HP", "value": itemData.system.hpBonus}}});
+    itemData.update({"system.itemModifiers": {nameHpMod: {"mod": "itemModifierHP", "value": itemData.system.hpBonus}}});
     itemData.update({"system.hpBonus": null});
   }
   if (itemData.system.mpBonus) {
     let keyMpMod = getID();
     let nameMpMod = ["si" + keyMpMod];
-    itemData.update({"system.itemModifiers": {nameMpMod: {"mod": "ItemModifier.MP", "value": itemData.system.mpBonus}}});
+    itemData.update({"system.itemModifiers": {nameMpMod: {"mod": "itemModifierMP", "value": itemData.system.mpBonus}}});
     itemData.update({"system.mpBonus": null});
   }
 };

--- a/module/migration.js
+++ b/module/migration.js
@@ -1,5 +1,6 @@
 import { addDarknessPoints } from "./darkness-points.js";
 import { getDefaultItemIcon } from "./item/item.js";
+import { getID } from "./util.js";
 /**
  * Perform a system migration for the entire World, applying migrations for Actors, Items, and Compendium packs
  * @return {Promise}      A Promise which resolves once the migration is completed
@@ -321,5 +322,20 @@ const migrateDarknessPoints = async function () {
     ui.notifications.info(game.i18n.localize("YZECORIOLIS.MigratedDP"), {
       permanent: true,
     });
+  }
+};
+
+export const migrateTalentBonus = function(itemData) {
+  if (itemData.system.hpBonus) {
+    let keyHpMod = getID();
+    let nameHpMod = ["si" + keyHpMod];
+    itemData.update({"system.itemModifiers": {nameHpMod: {"mod": "ItemModifier.HP", "value": itemData.system.hpBonus}}});
+    itemData.update({"system.hpBonus": null});
+  }
+  if (itemData.system.mpBonus) {
+    let keyMpMod = getID();
+    let nameMpMod = ["si" + keyMpMod];
+    itemData.update({"system.itemModifiers": {nameMpMod: {"mod": "ItemModifier.MP", "value": itemData.system.mpBonus}}});
+    itemData.update({"system.mpBonus": null});
   }
 };

--- a/module/templates.js
+++ b/module/templates.js
@@ -17,6 +17,8 @@ export const preloadHandlerbarsTemplates = async function () {
     "systems/yzecoriolis/templates/actor/parts/ship-logbooks.html",
     // dialog templates
     "systems/yzecoriolis/templates/dialog/automatic-fire.html",
+    // partial item templates
+    "systems/yzecoriolis/templates/item/modifiers.html",
   ];
 
   return loadTemplates(templatePaths);

--- a/module/yzecoriolis.js
+++ b/module/yzecoriolis.js
@@ -268,6 +268,10 @@ Hooks.once("init", async function () {
   Handlebars.registerHelper("AdditionalRollInfos", function () {
     return game.settings.get("yzecoriolis", "AdditionalRollInfos");
   });
+
+  Handlebars.registerHelper("getItemModifierName", function (mod) {
+    return CONFIG.YZECORIOLIS.itemModifierNames[mod];
+  });
 });
 
 // called after game data is loaded from severs. entities exist

--- a/template.json
+++ b/template.json
@@ -268,7 +268,8 @@
     ],
     "templates": {
       "base": {
-        "description": ""
+        "description": "",
+        "itemModifiers": {}
       },
       "gear": {
         "description": "",
@@ -277,7 +278,8 @@
         "cost": 0,
         "quantity": 1,
         "restricted": false,
-        "equipped": false
+        "equipped": false,
+        "itemModifiers": {}
       }
     },
     "gear": {

--- a/template.json
+++ b/template.json
@@ -290,9 +290,7 @@
       "templates": ["base"],
       "category": "",
       "cost": 0,
-      "groupConcept": "",
-      "hpBonus": 0,
-      "mpBonus": 0
+      "groupConcept": ""
     },
     "weapon": {
       "templates": ["gear"],

--- a/templates/actor/actor-sheet.html
+++ b/templates/actor/actor-sheet.html
@@ -103,8 +103,11 @@
         </li>
         <li class="entry flexrow">
           <div class="capitalize stat-label">{{localize "YZECORIOLIS.MovementRate"}}</div>
-          <div class="number">
+          <div class="number" style="display:inline-flex; padding-inline:2em;">
             <input class="input-value" type="text" name="system.movementRate" value="{{system.movementRate}}" data-dtype="Number" placeholder="0" />
+            {{#if system.movementRateMods}}
+              <input class="input-value" type="text" name="system.movementRateMods" value="" data-dtype="Number" placeholder="({{#if_gt system.movementRateMods 0}}+{{/if_gt}}{{system.movementRateMods}})" readonly/>
+            {{/if}}
           </div>
         </li>
         <li class="entry flexrow">

--- a/templates/dialog/automatic-fire.html
+++ b/templates/dialog/automatic-fire.html
@@ -1,13 +1,16 @@
+<h3>{{localize "YZECORIOLIS.AutomaticFire"}}</h3>
 <div>
-    <label style="position:relative; bottom:6px;">{{localize "YZECORIOLIS.AutomaticFire"}}</label>
     <input type='checkbox' name='automaticFire' data-dtype='Boolean' />
-    <span class='ignoredOnes' hidden style="display: none; position:relative; bottom:6px;"> ({{localize "YZECORIOLIS.AutomaticFireModifier"}})
+    <label style="position:relative; bottom:6px;">{{localize "YZECORIOLIS.AutomaticFire"}}</label>
+    <span class='ignoredOnes' hidden style="display: none; position:relative; bottom:6px;">
       <br/><br/>
-      <label style="position:relative; bottom:6px;">{{localize "YZECORIOLIS.Talent"}}: {{localize "YZECORIOLIS.TalentMachinegunner"}}?</label>
+      <em>({{localize "YZECORIOLIS.AutomaticFireModifier"}})</em>
+      <br/><br/>
       <input type='checkbox' name='machineGunner' data-dtype='Boolean' />
+      <label style="position:relative; bottom:6px;">{{localize "YZECORIOLIS.Talent"}}: {{localize "YZECORIOLIS.TalentMachinegunner"}}?</label>
       <br/>
-      <label style="position:relative; bottom:6px;">{{localize "YZECORIOLIS.Weapon"}}: {{localize "YZECORIOLIS.FeatureWeaponHighCapacity"}}?</label>
       <input type='checkbox' name='highCapacity' data-dtype='Boolean' />
+      <label style="position:relative; bottom:6px;">{{localize "YZECORIOLIS.Weapon"}}: {{localize "YZECORIOLIS.FeatureWeaponHighCapacity"}}?</label>
     </span>
 </div>
 <br/>

--- a/templates/item/armor-sheet.html
+++ b/templates/item/armor-sheet.html
@@ -44,14 +44,17 @@
                     </select>
                 </div>
 
+
                 <div class="resource numeric-input flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.ExtraFeatures"}}</label>
                     <input type="number" min="0" name="system.extraFeatures" value="{{system.extraFeatures}}"
                         data-dtype="Number" />
                 </div>
 
+
             </div>
         </div>
+        {{> systems/yzecoriolis/templates/item/modifiers.html }}
         <div class="feature-section flexrow">
             <ol>
                 <li class="special-feature-header flexrow">

--- a/templates/item/armor-sheet.html
+++ b/templates/item/armor-sheet.html
@@ -16,9 +16,11 @@
                     </select>
                 </div>
 
-                <div class="resource">
+                <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.Restricted"}}</label>
-                    <input type="checkbox" name="system.restricted" data-dtype="Boolean" {{checked system.restricted}} />
+                    <div style="margin-left: -1em;">
+                      <input type="checkbox" name="system.restricted" data-dtype="Boolean" {{checked system.restricted}} />
+                    </div>
                 </div>
 
 

--- a/templates/item/gear-sheet.html
+++ b/templates/item/gear-sheet.html
@@ -29,15 +29,12 @@
                     <input type="checkbox" name="system.restricted" data-dtype="Boolean" {{checked system.restricted}} />
                 </div>
                 <div class="resource flexrow">
-                    <label class="resource-label">{{localize "YZECORIOLIS.Bonus"}}</label>
-                    <input type="text" name="system.bonus" value="{{system.bonus}}" data-dtype="Number" />
-                </div>
-                <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.MoneyCost"}}</label>
                     <input type="text" name="system.cost" value="{{system.cost}}" data-dtype="Number" />
                 </div>
             </div>
         </div>
+        {{> systems/yzecoriolis/templates/item/modifiers.html }}
     </header>
 
     {{!-- Sheet Tab Navigation --}}

--- a/templates/item/gear-sheet.html
+++ b/templates/item/gear-sheet.html
@@ -24,9 +24,11 @@
                         {{/select}}
                     </select>
                 </div>
-                <div class="resource">
+                <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.Restricted"}}</label>
-                    <input type="checkbox" name="system.restricted" data-dtype="Boolean" {{checked system.restricted}} />
+                    <div style="margin-left: -1em;">
+                      <input type="checkbox" name="system.restricted" data-dtype="Boolean" {{checked system.restricted}} />
+                    </div>
                 </div>
                 <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.MoneyCost"}}</label>

--- a/templates/item/injury-sheet.html
+++ b/templates/item/injury-sheet.html
@@ -5,9 +5,11 @@
             <h1 class="charname"><input name="name" type="text" value="{{name}}" placeholder="Name" /></h1>
         </div>
         <div class="flexcol flex1">
-            <div class="resource">
+            <div class="resource flexrow">
                 <label class="resource-label">{{localize "YZECORIOLIS.FatalInjury"}}</label>
-                <input type="checkbox" name="system.fatal" data-dtype="Boolean" {{checked system.fatal}} />
+                <div style="margin-left: -1em;">
+                  <input type="checkbox" name="system.fatal" data-dtype="Boolean" {{checked system.fatal}} />
+                </div>
             </div>
             {{#if system.fatal}}
               <div class="resource numeric-input flexrow">

--- a/templates/item/injury-sheet.html
+++ b/templates/item/injury-sheet.html
@@ -21,12 +21,8 @@
                 <input type="text" name="system.healTime" value="{{system.healTime}}"
                     data-dtype="String" />
             </div>
-            <div class="resource numeric-input flexrow">
-                <label class="resource-label">{{localize "YZECORIOLIS.ModifierForRoll"}}</label>
-                <input type="number" min="0" name="system.bonus" value="{{system.bonus}}"
-                    data-dtype="Number" />
-            </div>
         </div>
+        {{> systems/yzecoriolis/templates/item/modifiers.html }}
     </header>
 
     {{!-- Sheet Tab Navigation --}}

--- a/templates/item/modifiers.html
+++ b/templates/item/modifiers.html
@@ -13,39 +13,39 @@
                     <div class="feature-name">
                         <select name="system.itemModifiers.{{id}}.mod">
                             {{#select itemmod.mod}}
-                            <option value="ItemModifier.None" disabled  selected>{{localize "YZECORIOLIS.ItemModifierSelect"}}</option>
+                            <option value="itemModifierNone" disabled  selected>{{localize "YZECORIOLIS.ItemModifierSelect"}}</option>
                             <optgroup label="{{localize "YZECORIOLIS.Attributes"}}">
-                              <option value="ItemModifier.AttrStrength">{{localize "YZECORIOLIS.AttrStrength"}}</option>
-                              <option value="ItemModifier.AttrAgility">{{localize "YZECORIOLIS.AttrAgility"}}</option>
-                              <option value="ItemModifier.AttrWits">{{localize "YZECORIOLIS.AttrWits"}}</option>
-                              <option value="ItemModifier.AttrEmpathy">{{localize "YZECORIOLIS.AttrEmpathy"}}</option>
+                              <option value="itemModifierAttrStrength">{{localize "YZECORIOLIS.AttrStrength"}}</option>
+                              <option value="itemModifierAttrAgility">{{localize "YZECORIOLIS.AttrAgility"}}</option>
+                              <option value="itemModifierAttrWits">{{localize "YZECORIOLIS.AttrWits"}}</option>
+                              <option value="itemModifierAttrEmpathy">{{localize "YZECORIOLIS.AttrEmpathy"}}</option>
                             </optgroup>
                             <optgroup label="{{localize "YZECORIOLIS.SkillCatGeneral"}}">
-                              <option value="ItemModifier.SkillDex">{{localize "YZECORIOLIS.SkillDexterity"}}</option>
-                              <option value="ItemModifier.SkillForce">{{localize "YZECORIOLIS.SkillForce"}}</option>
-                              <option value="ItemModifier.SkillInf">{{localize "YZECORIOLIS.SkillInfiltration"}}</option>
-                              <option value="ItemModifier.SkillMan">{{localize "YZECORIOLIS.SkillManipulation"}}</option>
-                              <option value="ItemModifier.SkillMelee">{{localize "YZECORIOLIS.SkillMeleeCombat"}}</option>
-                              <option value="ItemModifier.SkillObs">{{localize "YZECORIOLIS.SkillObservation"}}</option>
-                              <option value="ItemModifier.SkillRange">{{localize "YZECORIOLIS.SkillRangedCombat"}}</option>
-                              <option value="ItemModifier.SkillSurv">{{localize "YZECORIOLIS.SkillSurvival"}}</option>
+                              <option value="itemModifierSkillDex">{{localize "YZECORIOLIS.SkillDexterity"}}</option>
+                              <option value="itemModifierSkillForce">{{localize "YZECORIOLIS.SkillForce"}}</option>
+                              <option value="itemModifierSkillInf">{{localize "YZECORIOLIS.SkillInfiltration"}}</option>
+                              <option value="itemModifierSkillMan">{{localize "YZECORIOLIS.SkillManipulation"}}</option>
+                              <option value="itemModifierSkillMelee">{{localize "YZECORIOLIS.SkillMeleeCombat"}}</option>
+                              <option value="itemModifierSkillObs">{{localize "YZECORIOLIS.SkillObservation"}}</option>
+                              <option value="itemModifierSkillRange">{{localize "YZECORIOLIS.SkillRangedCombat"}}</option>
+                              <option value="itemModifierSkillSurv">{{localize "YZECORIOLIS.SkillSurvival"}}</option>
                             </optgroup>
                             <optgroup label="{{localize "YZECORIOLIS.SkillCatAdvanced"}}">
-                              <option value="ItemModifier.SkillCom">{{localize "YZECORIOLIS.SkillCommand"}}</option>
-                              <option value="ItemModifier.SkillCult">{{localize "YZECORIOLIS.SkillCulture"}}</option>
-                              <option value="ItemModifier.SkillData">{{localize "YZECORIOLIS.SkillDataDjinn"}}</option>
-                              <option value="ItemModifier.SkillMedi">{{localize "YZECORIOLIS.SkillMedicurgy"}}</option>
-                              <option value="ItemModifier.SkillMys">{{localize "YZECORIOLIS.SkillMysticPowers"}}</option>
-                              <option value="ItemModifier.SkillPil">{{localize "YZECORIOLIS.SkillPilot"}}</option>
-                              <option value="ItemModifier.SkillSci">{{localize "YZECORIOLIS.SkillScience"}}</option>
-                              <option value="ItemModifier.SkillTech">{{localize "YZECORIOLIS.SkillTechnology"}}</option>
+                              <option value="itemModifierSkillCom">{{localize "YZECORIOLIS.SkillCommand"}}</option>
+                              <option value="itemModifierSkillCult">{{localize "YZECORIOLIS.SkillCulture"}}</option>
+                              <option value="itemModifierSkillData">{{localize "YZECORIOLIS.SkillDataDjinn"}}</option>
+                              <option value="itemModifierSkillMedi">{{localize "YZECORIOLIS.SkillMedicurgy"}}</option>
+                              <option value="itemModifierSkillMys">{{localize "YZECORIOLIS.SkillMysticPowers"}}</option>
+                              <option value="itemModifierSkillPil">{{localize "YZECORIOLIS.SkillPilot"}}</option>
+                              <option value="itemModifierSkillSci">{{localize "YZECORIOLIS.SkillScience"}}</option>
+                              <option value="itemModifierSkillTech">{{localize "YZECORIOLIS.SkillTechnology"}}</option>
                             </optgroup>
                             <optgroup label="{{localize "YZECORIOLIS.Other"}}">
-                              <option value="ItemModifier.HP">{{localize "YZECORIOLIS.HitPoints"}}</option>
-                              <option value="ItemModifier.MP">{{localize "YZECORIOLIS.MindPoints"}}</option>
-                              <option value="ItemModifier.Rad">{{localize "YZECORIOLIS.Radiation"}}</option>
-                              <option value="ItemModifier.Enc">{{localize "YZECORIOLIS.Encumbrance"}}</option>
-                              <option value="ItemModifier.MR">{{localize "YZECORIOLIS.MovementRate"}}</option>
+                              <option value="itemModifierHP">{{localize "YZECORIOLIS.HitPoints"}}</option>
+                              <option value="itemModifierMP">{{localize "YZECORIOLIS.MindPoints"}}</option>
+                              <option value="itemModifierRad">{{localize "YZECORIOLIS.Radiation"}}</option>
+                              <option value="itemModifierEnc">{{localize "YZECORIOLIS.Encumbrance"}}</option>
+                              <option value="itemModifierMR">{{localize "YZECORIOLIS.MovementRate"}}</option>
                             </optgroup>
                             {{/select}}
                         </select>

--- a/templates/item/modifiers.html
+++ b/templates/item/modifiers.html
@@ -1,0 +1,62 @@
+<div class="feature-section flexrow">
+            <ol>
+                <li class="special-feature-header flexrow">
+                    <h3 class="feature-name flexrow">{{localize "YZECORIOLIS.ItemModifiers"}}</h3>
+                    <div class="feature-controls">
+                        <a class="feature-control itemModifier-create" title='{{localize "YZECORIOLIS.ItemModifierCreate"}}'>
+                            <i class="fas fa-plus"></i> {{localize "YZECORIOLIS.Add"}}
+                        </a>
+                    </div>
+                </li>
+                {{#each system.itemModifiers as |itemmod id|}}
+                <li class="special-feature flexrow"  data-item-id="{{id}}">
+                    <div class="feature-name">
+                        <select name="system.itemModifiers.{{id}}.mod">
+                            {{#select itemmod.mod}}
+                            <option value="ItemModifier.None" disabled  selected>{{localize "YZECORIOLIS.ItemModifierSelect"}}</option>
+                            <optgroup label="{{localize "YZECORIOLIS.Attributes"}}">
+                              <option value="ItemModifier.AttrStrength">{{localize "YZECORIOLIS.AttrStrength"}}</option>
+                              <option value="ItemModifier.AttrAgility">{{localize "YZECORIOLIS.AttrAgility"}}</option>
+                              <option value="ItemModifier.AttrWits">{{localize "YZECORIOLIS.AttrWits"}}</option>
+                              <option value="ItemModifier.AttrEmpathy">{{localize "YZECORIOLIS.AttrEmpathy"}}</option>
+                            </optgroup>
+                            <optgroup label="{{localize "YZECORIOLIS.SkillCatGeneral"}}">
+                              <option value="ItemModifier.SkillDex">{{localize "YZECORIOLIS.SkillDexterity"}}</option>
+                              <option value="ItemModifier.SkillForce">{{localize "YZECORIOLIS.SkillForce"}}</option>
+                              <option value="ItemModifier.SkillInf">{{localize "YZECORIOLIS.SkillInfiltration"}}</option>
+                              <option value="ItemModifier.SkillMan">{{localize "YZECORIOLIS.SkillManipulation"}}</option>
+                              <option value="ItemModifier.SkillMelee">{{localize "YZECORIOLIS.SkillMeleeCombat"}}</option>
+                              <option value="ItemModifier.SkillObs">{{localize "YZECORIOLIS.SkillObservation"}}</option>
+                              <option value="ItemModifier.SkillRange">{{localize "YZECORIOLIS.SkillRangedCombat"}}</option>
+                              <option value="ItemModifier.SkillSurv">{{localize "YZECORIOLIS.SkillSurvival"}}</option>
+                            </optgroup>
+                            <optgroup label="{{localize "YZECORIOLIS.SkillCatAdvanced"}}">
+                              <option value="ItemModifier.SkillCom">{{localize "YZECORIOLIS.SkillCommand"}}</option>
+                              <option value="ItemModifier.SkillCult">{{localize "YZECORIOLIS.SkillCulture"}}</option>
+                              <option value="ItemModifier.SkillData">{{localize "YZECORIOLIS.SkillDataDjinn"}}</option>
+                              <option value="ItemModifier.SkillMedi">{{localize "YZECORIOLIS.SkillMedicurgy"}}</option>
+                              <option value="ItemModifier.SkillMys">{{localize "YZECORIOLIS.SkillMysticPowers"}}</option>
+                              <option value="ItemModifier.SkillPil">{{localize "YZECORIOLIS.SkillPilot"}}</option>
+                              <option value="ItemModifier.SkillSci">{{localize "YZECORIOLIS.SkillScience"}}</option>
+                              <option value="ItemModifier.SkillTech">{{localize "YZECORIOLIS.SkillTechnology"}}</option>
+                            </optgroup>
+                            <optgroup label="{{localize "YZECORIOLIS.Other"}}">
+                              <option value="ItemModifier.HP">{{localize "YZECORIOLIS.HitPoints"}}</option>
+                              <option value="ItemModifier.MP">{{localize "YZECORIOLIS.MindPoints"}}</option>
+                              <option value="ItemModifier.Rad">{{localize "YZECORIOLIS.Radiation"}}</option>
+                              <option value="ItemModifier.Enc">{{localize "YZECORIOLIS.Encumbrance"}}</option>
+                              <option value="ItemModifier.MR">{{localize "YZECORIOLIS.MovementRate"}}</option>
+                            </optgroup>
+                            {{/select}}
+                        </select>
+                    </div>
+                    <div style="flex: 1 1 10%;" title="{{localize "YZECORIOLIS.ItemModifierValue"}}">
+                        <input name="system.itemModifiers.{{id}}.value" type="number" value="{{#if itemmod.value}}{{itemmod.value}}{{else}}0{{/if}}" style="text-align: center;"/>
+                    </div>
+                    <div class="feature-controls">
+                      <a class="feature-control itemModifier-delete" title="{{localize 'YZECORIOLIS.ItemModifierDelete'}}" data-item-id="{{id}}"><i class="fas fa-trash"></i></a>
+                    </div>
+                </li>
+                {{/each}}
+            </ol>
+</div>

--- a/templates/item/shipFeature-sheet.html
+++ b/templates/item/shipFeature-sheet.html
@@ -30,16 +30,18 @@
             {{/select}}
           </select>
         </div>
-        <div class="resource">
+        <div class="resource flexrow">
           <label class="resource-label">
             {{localize "YZECORIOLIS.Restricted"}}
           </label>
-          <input
-            type="checkbox"
-            name="system.restricted"
-            data-dtype="Boolean"
-            {{checked system.restricted}}
-          />
+          <div style="margin-left: -1em;">
+            <input
+              type="checkbox"
+              name="system.restricted"
+              data-dtype="Boolean"
+              {{checked system.restricted}}
+            />
+          </div>
         </div>
         <div class="resource flexrow">
           <label class="resource-label">

--- a/templates/item/shipModule-sheet.html
+++ b/templates/item/shipModule-sheet.html
@@ -60,14 +60,18 @@
                     </select>
                 </div>
 
-                <div class="resource">
+                <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.Restricted"}}</label>
-                    <input type="checkbox" name="system.restricted" data-dtype="Boolean" {{checked system.restricted}} />
+                    <div style="margin-left: -1em;">
+                      <input type="checkbox" name="system.restricted" data-dtype="Boolean" {{checked system.restricted}} />
+                    </div>
                 </div>
 
-                <div class="resource">
+                <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.Enabled"}}</label>
-                    <input type="checkbox" name="system.enabled" data-dtype="Boolean" {{checked system.enabled}} />
+                    <div style="margin-left: -1em;">
+                      <input type="checkbox" name="system.enabled" data-dtype="Boolean" {{checked system.enabled}} />
+                    </div>
                 </div>
 
 

--- a/templates/item/talent-sheet.html
+++ b/templates/item/talent-sheet.html
@@ -26,18 +26,6 @@
                     </select>
                 </div>
                 {{/if_eq}}
-                {{!-- Edit HP Bonus for this talent --}}
-                <div class="resource flexrow">
-                    <label class="cost-label flexrow">{{localize "YZECORIOLIS.HPBonus"}}</label>
-                    <input class="cost-input flexrow" type="text" name="system.hpBonus" value="{{system.hpBonus}}"
-                        data-dtype="Number" />
-                </div>
-                {{!-- Edit MP Bonus for this talent --}}
-                <div class="resource flexrow">
-                    <label class="cost-label flexrow">{{localize "YZECORIOLIS.MPBonus"}}</label>
-                    <input class="cost-input flexrow" type="text" name="system.mpBonus" value="{{system.mpBonus}}"
-                        data-dtype="Number" />
-                </div>
                 {{!-- Display the cost if it has any --}}
                 {{#talentHasCost system.category}}
                 <div class="flexrow">

--- a/templates/item/talent-sheet.html
+++ b/templates/item/talent-sheet.html
@@ -44,7 +44,7 @@
                     <label class="cost-label flexrow">{{localize "YZECORIOLIS.MoneyCost"}}</label>
                     <input class="cost-input flexrow" type="text" name="system.cost" value="{{system.cost}}"
                         data-dtype="Number" />
-                    <label class="cost-currency-label flexrow">{{localize "YZECORIOLIS.Birr"}}</label>
+                    <label class="cost-currency-label flexrow" style="padding-left: 0.5em;">{{localize "YZECORIOLIS.Birr"}}</label>
                 </div>
                 {{/talentHasCost}}
             </div>

--- a/templates/item/talent-sheet.html
+++ b/templates/item/talent-sheet.html
@@ -49,6 +49,7 @@
                 {{/talentHasCost}}
             </div>
         </div>
+        {{> systems/yzecoriolis/templates/item/modifiers.html }}
     </header>
 
     {{!-- Sheet Tab Navigation --}}

--- a/templates/item/weapon-sheet.html
+++ b/templates/item/weapon-sheet.html
@@ -119,6 +119,7 @@
 
             </div>
         </div>
+        {{> systems/yzecoriolis/templates/item/modifiers.html }}
         <div class="feature-section flexrow">
             <ol>
                 <li class="special-feature-header flexrow">

--- a/templates/item/weapon-sheet.html
+++ b/templates/item/weapon-sheet.html
@@ -59,9 +59,11 @@
                     </select>
                 </div>
 
-                <div class="resource">
+                <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.Restricted"}}</label>
-                    <input type="checkbox" name="system.restricted" data-dtype="Boolean" {{checked system.restricted}} />
+                    <div style="margin-left: -1em;">
+                      <input type="checkbox" name="system.restricted" data-dtype="Boolean" {{checked system.restricted}} />
+                    </div>
                 </div>
 
 
@@ -82,19 +84,25 @@
                     </select>
                 </div>
 
-                <div class="resource">
+                <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.Automatic"}}</label>
-                    <input type="checkbox" name="system.automatic" data-dtype="Boolean" {{checked system.automatic}} />
+                    <div style="margin-left: -1em;">
+                      <input type="checkbox" name="system.automatic" data-dtype="Boolean" {{checked system.automatic}} />
+                    </div>
                 </div>
 
-                <div class="resource">
+                <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.Explosive"}}</label>
-                    <input type="checkbox" name="system.explosive" data-dtype="Boolean" {{checked system.explosive}} />
+                    <div style="margin-left: -1em;">
+                      <input type="checkbox" name="system.explosive" data-dtype="Boolean" {{checked system.explosive}} />
+                    </div>
                 </div>
 
-                <div class="resource">
+                <div class="resource flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.Melee"}}</label>
-                    <input type="checkbox" name="system.melee" data-dtype="Boolean" {{checked system.melee}} />
+                    <div style="margin-left: -1em;">
+                      <input type="checkbox" name="system.melee" data-dtype="Boolean" {{checked system.melee}} />
+                    </div>
                 </div>
 
                 {{#if system.explosive}}

--- a/templates/sidebar/item.html
+++ b/templates/sidebar/item.html
@@ -1,7 +1,7 @@
 <div class="yzecoriolis chat-item">
     <div class="header">
         <img src="{{icon}}" class="chat-item-img" title="{{localize (getItemTypeName item.type)}}">
-        <h3>{{item.name}}</h3>
+        <h3><strong>{{item.name}}</strong></h3>
 
         {{#if_eq item.type 'talent'}}
         <h4>[ {{localize (getTalentCategoryName item.system.category)}} ]</h4>
@@ -56,12 +56,6 @@
         {{#if item.system.cost}}
         <p><strong>{{localize "YZECORIOLIS.Cost"}} : </strong>{{item.system.cost}} {{localize "YZECORIOLIS.Birr"}}</p>
         {{/if}}
-        {{#if item.system.hpBonus}}
-        <p><strong>{{localize "YZECORIOLIS.HPBonus"}}: </strong>{{item.system.hpBonus}}</p>
-        {{/if}}
-        {{#if item.system.mpBonus}}
-        <p><strong>{{localize "YZECORIOLIS.MPBonus"}}: </strong>{{item.system.mpBonus}}</p>
-        {{/if}}
     </div>
     {{/if_eq}}
 
@@ -90,6 +84,29 @@
     </div>
     {{/if_eq}}
 
+    <!-- FEATURES -->
+    {{#if item.system.special}}
+      <strong style="border-bottom: 1px solid var(--color-underline-header);">{{localize "YZECORIOLIS.Special"}}</strong>
+      <ul>
+        {{#each item.system.special as |feature id|}}
+          <li data-item-id="{{id}}">{{feature}}</li>
+        {{/each}}
+      </ul>
+    {{/if}}
+
+    <!-- ITEM-MODIFIERS -->
+    {{#if itemModifiers}}
+      <strong style="border-bottom: 1px solid var(--color-underline-header);">{{localize "YZECORIOLIS.ItemModifiers"}}</strong>
+      <ul>
+        {{#each itemModifiers as |itemModifier id|}}
+          <li data-item-id="{{id}}">{{localize (getItemModifierName mod)}}: {{value}}</li>
+        {{/each}}
+      </ul>
+    {{/if}}
+
     <!-- DESCRIPTION -->
-    {{{item.system.description}}}
+    {{#if item.system.description}}
+      <strong style="border-bottom: 1px solid var(--color-underline-header);">{{localize "YZECORIOLIS.Description"}}</strong>
+      {{{item.system.description}}}
+    {{/if}}
 </div>


### PR DESCRIPTION
Resolves #160, resolves #37

matches inactivity-closed pull #209


This adds the option for modifiers on items (critical injuries, talents, gear, weapons, armor).
It is inspired by the [Forbidden Lands](https://github.com/fvtt-fria-ligan/forbidden-lands-foundry-vtt)-Repo.

![image](https://user-images.githubusercontent.com/36819852/199265744-5258e769-58ab-4bd3-8cd7-63c4294496b9.png) 
![image](https://user-images.githubusercontent.com/36819852/199268165-e6546d66-68ea-41d0-9ebb-06544736f6de.png)
![image](https://user-images.githubusercontent.com/36819852/199458454-fd6ca8fe-27bc-49f5-85be-82f5c7c781e3.png)
![image](https://github.com/winks-vtt/yze-coriolis/assets/36819852/0b6e69ff-ba86-465d-9c0b-bd414ffe92ab)


### **To-Do**
- [X] basic integration
- [X] calculation for Hit Points
- - [X] migrate Talent HP Bonus
- [X] calculation for Mind Points
- - [X] migrate Talent MP Bonus
- [X] calculation for Radiation
- [X] calculation for Movement Rate
- [X] calculation for Encumbrance
- [X] adding modifiers to item-posts (to chat)
- [ ] option for calculation in rolls (attributes and skills)
- [ ] adding modifiers to advanced-roll infos
- [ ] CSS / .less stuff (right now it is just replaced in the CSS and works on the Special Feature-parts, should it be on his own?)