### PR TITLE
add settings for DP-Display

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -385,6 +385,8 @@
   "YZECORIOLIS.SettingAdditionalRollInfosPC": "Nur für Spielercharaktere",
   "YZECORIOLIS.SettingAdditionalRollInfosNPC": "Nur für Nicht-Spielercharaktere",
   "YZECORIOLIS.SettingAdditionalRollInfosAll": "Für alle Charaktere",
+  "YZECORIOLIS.SettingDarknessPointsVisibility": "Zeige Spielern FP",
+  "YZECORIOLIS.SettingDarknessPointsVisibilityHint": "Wenn aktviviert, wird den Spielern die Menge der Finsternispunkte in der Spielflächen-Steuerung angezeigt.",
 
   "YZECORIOLIS.EnergyPointsReset": "Zuvor der Mannschaft zu geordnete Leistungspunkte stehen dem Schiffsreaktor wieder zur Verfügung.",
   "YZECORIOLIS.InvalidEPPermissions": "Du hast keine Berechtigung die LP-Verteilung zu verändern.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -385,6 +385,8 @@
   "YZECORIOLIS.SettingAdditionalRollInfosPC": "Only for Player Characters",
   "YZECORIOLIS.SettingAdditionalRollInfosNPC": "Only for Non-Player Characters",
   "YZECORIOLIS.SettingAdditionalRollInfosAll": "For all Characters",
+  "YZECORIOLIS.SettingDarknessPointsVisibility": "Show Players DP",
+  "YZECORIOLIS.SettingDarknessPointsVisibilityHint": "If this is enabled the Darkness Points will be displayed for the players in the Layer Controls.",
 
   "YZECORIOLIS.EnergyPointsReset": "Energy Points previously assigned to crew returned to ship reactor.",
   "YZECORIOLIS.InvalidEPPermissions": "You do not have permission to change ship EP distribution.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -367,6 +367,8 @@
   "YZECORIOLIS.SettingAdditionalRollInfosPC": "Uniquement pour les personnages joueurs",
   "YZECORIOLIS.SettingAdditionalRollInfosNPC": "Uniquement pour les personnages non-joueurs",
   "YZECORIOLIS.SettingAdditionalRollInfosAll": "Pour tous les personnages",
+  "YZECORIOLIS.SettingDarknessPointsVisibility": "Permettre aux joueurs de voir les PNs",
+  "YZECORIOLIS.SettingDarknessPointsVisibilityHint": "Si activé, les joueurs pourront voir le nombre de PNs à partir du bouton présent dans la barre de contrôle."
 
   "YZECORIOLIS.EnergyPointsReset": "Les Points d'Énergie assignés sont redirigés vers le réacteur du vaisseau.",
   "YZECORIOLIS.InvalidEPPermissions": "Vous n'avez pas la permission de changer la distribution des PE du vaisseau.",

--- a/module/settings.js
+++ b/module/settings.js
@@ -67,4 +67,14 @@ export const registerSystemSettings = function () {
     },
     default: "all",
   });
+
+  game.settings.register("yzecoriolis", "DarknessPointsVisibility", {
+    name: game.i18n.localize("YZECORIOLIS.SettingDarknessPointsVisibility"),
+    hint: game.i18n.localize("YZECORIOLIS.SettingDarknessPointsVisibilityHint"),
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false,
+    onChange: debouncedReload,
+  });
 };

--- a/module/yzecoriolis.js
+++ b/module/yzecoriolis.js
@@ -377,7 +377,9 @@ Hooks.on("getSceneControlButtons", (controls) => {
       title: "YZECORIOLIS.DarknessPointsControls",
       icon: "fas fa-moon",
       buttons: true,
-      visible: game.user.isGM,
+      visible: game.settings.get("yzecoriolis", "DarknessPointsVisibility")
+        ? true
+        : game.user.isGM,
       onClick: () => {
         DarknessPointDisplay.render();
       },


### PR DESCRIPTION
Addition to #234 from @coderunner 

This adds a setting for the GM to let players see the Darkness Point-Display or not (default: not).

background is that commit from @AlexOkafor 
> I added one minor thing in that the display hud isn't accessible to non-GM players. I didn't want to take control away from the GM in the event they want to keep DPs secret from the players. I think unveiling the DP to players generally on their own could probably be a setting.


I would always play with open DP (and most of I know of) and even the crb encourages it:
> The Darkness Points are a dramatic tool for the GM. Using them, he can put obstacles in the PCs’ way or help NPCs in a pinch. The DP also have a psychological effect on the players – seeing the growing pool of tokens becomes an omen that something bad is about to happen.

But I get the idea to let the GM choose as there are groups and situations where it is better to have less insight in the darkness between the stars.
So here is the compromise :D