### PR TITLE
broken blastPower

### DIFF
--- a/module/item/item.js
+++ b/module/item/item.js
@@ -1,4 +1,5 @@
 import { coriolisRoll, coriolisModifierDialog } from "../coriolis-roll.js";
+import { migrateBlastPower } from "../migration.js";
 /**
  * Extend the basic Item with some very simple modifications.
  * @extends {Item}
@@ -15,6 +16,9 @@ export class yzecoriolisItem extends Item {
     // Get the Item's data
     const itemData = this;
     if (itemData.type === "talent") this._prepareTalentData(itemData);
+
+    // Migrate wrong blastPower-values
+    if (itemData.type === "weapon" && itemData.system.explosive) migrateBlastPower(itemData);
   }
 
   // eslint-disable-next-line no-unused-vars

--- a/module/migration.js
+++ b/module/migration.js
@@ -334,3 +334,10 @@ export const migrateActorKeyArtIfNeeded = function (actor) {
     actor.update(createActorKeyArtUpdate(actor));
   }
 };
+
+export const migrateBlastPower = function(itemData) {
+  if (itemData.system.crit.blastPower) {
+    itemData.update({"system.blastPower": itemData.system.crit.blastPower});
+    itemData.update({"system.crit.blastPower": null});
+  }
+};

--- a/templates/item/weapon-sheet.html
+++ b/templates/item/weapon-sheet.html
@@ -100,7 +100,7 @@
                 {{#if system.explosive}}
                 <div class="resource numeric-input flexrow">
                     <label class="resource-label">{{localize "YZECORIOLIS.BlastPower"}}</label>
-                    <input type="number" min="0" name="system.crit.blastPower" value="{{system.crit.blastPower}}"
+                    <input type="number" min="0" name="system.blastPower" value="{{system.blastPower}}"
                         data-dtype="Number" />
                 </div>
 


### PR DESCRIPTION
resolves #242 

The Blast Power were wrongly saved and updated.
Because of this, the display within the actor-sheet, roll-infos and post-to-chat were wrong.

This should fix the whole issue.

@coderunner / @AlexOkafor 
I did fix that the blastPower were wrongly stored into `itemData.crit.blastPower` but don't get why there is `itemData.blastpower` and `itemData.blastradius` besides `itemData.blastPower` and `itemData.blastRadius`. 🤔
![image](https://github.com/winks-vtt/yze-coriolis/assets/36819852/00c1c32d-f0f3-4e07-aa3f-fe2862837600)
