### PR TITLE
changes the feat Roll Visibility to an option

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -385,7 +385,9 @@
   "YZECORIOLIS.SettingAdditionalRollInfosNPC": "Nur für Nicht-Spielercharaktere",
   "YZECORIOLIS.SettingAdditionalRollInfosAll": "Für alle Charaktere",
   "YZECORIOLIS.SettingDarknessPointsVisibility": "Zeige Spielern FP",
-  "YZECORIOLIS.SettingDarknessPointsVisibilityHint": "Wenn aktviviert, wird den Spielern die Menge der Finsternispunkte in der Spielflächen-Steuerung angezeigt.",
+  "YZECORIOLIS.SettingDarknessPointsVisibilityHint": "Wenn aktiviert, wird den Spielern die Menge der Finsternispunkte in der Spielflächen-Steuerung angezeigt.",
+  "YZECORIOLIS.SettingRollVisibility": "Sichtbarkeit des Wurfes im Dialog abfragen",
+  "YZECORIOLIS.SettingRollVisibilityHint": "Wenn aktiviert kann man die Sichtbarkeit des Wurfes (öffentlich, privat-SL, verdeckt-SL oder privat) durch den Wurfdialog anpassen. Dies überschreibt Module mit ähnlichen Funktionen.",
 
   "YZECORIOLIS.EnergyPointsReset": "Zuvor der Mannschaft zu geordnete Leistungspunkte stehen dem Schiffsreaktor wieder zur Verfügung.",
   "YZECORIOLIS.InvalidEPPermissions": "Du hast keine Berechtigung die LP-Verteilung zu verändern.",
@@ -426,5 +428,10 @@
   "YZECORIOLIS.AutomaticFire": "Automatisches Feuer",
   "YZECORIOLIS.AutomaticFireModifier": "Modifikator von -2 auf deinen Angriffswurf",
   "YZECORIOLIS.RollTotal": "Gesamtwurf",
-  "YZECORIOLIS.RollSubstitute": "Verzweiflungswurf (2d6) anstatt"
+  "YZECORIOLIS.RollSubstitute": "Verzweiflungswurf (2d6) anstatt",
+  "YZECORIOLIS.RollVisibility": "Wurf Sichtbarkeit",
+  "YZECORIOLIS.PublicRoll": "Öffentlicher Wurf",
+  "YZECORIOLIS.PrivateGMRoll": "Privater SL-Wurf",
+  "YZECORIOLIS.BlindGMRoll": "Verdeckter SL-Wurf",
+  "YZECORIOLIS.SelfRoll": "Privater Wurf"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -386,6 +386,8 @@
   "YZECORIOLIS.SettingAdditionalRollInfosAll": "For all Characters",
   "YZECORIOLIS.SettingDarknessPointsVisibility": "Show Players DP",
   "YZECORIOLIS.SettingDarknessPointsVisibilityHint": "If this is enabled the Darkness Points will be displayed for the players in the Layer Controls.",
+  "YZECORIOLIS.SettingRollVisibility": "Change roll visibility via roll-dialog",
+  "YZECORIOLIS.SettingRollVisibilityHint": "If this is enabled, the kind of roll (public, private, blind or self) can be choosen from the roll-dialog. This may overwrite modules with the same functionality.",
 
   "YZECORIOLIS.EnergyPointsReset": "Energy Points previously assigned to crew returned to ship reactor.",
   "YZECORIOLIS.InvalidEPPermissions": "You do not have permission to change ship EP distribution.",

--- a/module/coriolis-roll.js
+++ b/module/coriolis-roll.js
@@ -7,8 +7,9 @@ export async function coriolisModifierDialog(
   let automaticFire = false;
   let machineGunner = false;
   let highCapacity = false;
-  let rollMode = game.settings.get("core", "rollMode");
-  const callback = function (modifier) {
+  let rollVisibility = game.settings.get("yzecoriolis", "RollVisibility");
+  let rollMode = rollVisibility ? game.settings.get("core", "rollMode") : false;
+    const callback = function (modifier) {
     // eslint-disable-next-line no-unused-vars
     return function (html) {
       modifierCallback(modifier, {
@@ -22,9 +23,11 @@ export async function coriolisModifierDialog(
   };
 
   let content =
-    await renderTemplate(
-      "systems/yzecoriolis/templates/dialog/roll-visibility.html"
-    ) +
+    (rollVisibility
+      ? await renderTemplate(
+        "systems/yzecoriolis/templates/dialog/roll-visibility.html"
+        )
+      : "") +
     (automaticWeapon
       ? await renderTemplate(
           "systems/yzecoriolis/templates/dialog/automatic-fire.html"
@@ -115,11 +118,13 @@ export async function coriolisModifierDialog(
     },
     default: "zero",
     render: (html) => {
-      const rollModeSelect = document.getElementById("dialogRollModeId");
-      rollModeSelect.value = rollMode;
-      html.find("select[name='dialogRollMode']").change((ev) => {
-        rollMode = ev.target.value;
-      });
+      if (rollVisibility) {
+        const rollModeSelect = document.getElementById("dialogRollModeId");
+        rollModeSelect.value = rollMode;
+        html.find("select[name='dialogRollMode']").change((ev) => {
+          rollMode = ev.target.value;
+        });
+      }
       html.find("input[name='automaticFire']").click(() => {
         automaticFire = !automaticFire;
         if (automaticFire) {
@@ -180,7 +185,9 @@ export function coriolisPrayerModifierDialog(modifierCallback) {
  * @param  {} rollData contains all data necessary to make a roll in Coriolis.
  */
 export async function coriolisRoll(chatOptions, rollData) {
-  chatOptions.rollMode = rollData.additionalData?.rollMode || chatOptions.rollMode;
+  if (game.settings.get("yzecoriolis", "RollVisibility")) {
+    chatOptions.rollMode = rollData.additionalData?.rollMode || chatOptions.rollMode;
+  }
   let errorObj = { error: "YZECORIOLIS.ErrorsInvalidSkillRoll" };
   const isValid = isValidRoll(rollData, errorObj);
   if (!isValid) {

--- a/module/settings.js
+++ b/module/settings.js
@@ -77,4 +77,14 @@ export const registerSystemSettings = function () {
     default: false,
     onChange: debouncedReload,
   });
+
+  game.settings.register("yzecoriolis", "RollVisibility", {
+    name: game.i18n.localize("YZECORIOLIS.SettingRollVisibility"),
+    hint: game.i18n.localize("YZECORIOLIS.SettingRollVisibilityHint"),
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: true,
+    onChange: debouncedReload,
+  });
 };


### PR DESCRIPTION
Many people already use different styles of ways for the roll-visbilites (like the module dice tray).

The last implemented feat is a great idea but some people prefer to handle that with modules or the foundry-default way. The problem is that this feat overwrites all other modules.

This request makes it an option where the GM can choose if he wants to use it or not.


+ added german translation