### PR TITLE
Extension for itemModifiers

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -30,6 +30,7 @@
   "YZECORIOLIS.ErrorsActorNotHasItemForMacro": "Der von dir ausgewählte Charakter besitzt keine Ausrüstung mit diesem Namen.",
   "YZECORIOLIS.ErrorsNotOwnedItemForMacro": "Du kannst nur Makros für Ausrüstungen erstellen, die du besitzt.",
   "YZECORIOLIS.ErrorsNoItemForMacro": "Für dieses Element kannst du kein Makro erstellen. Nur für Waffen, Sprengstoffe und Panzerungen.",
+  "YZECORIOLIS.ErrorsAlreadyPushed": "Für diesen Wurf gab es bereits ein Gebet. Er kann nicht erneut wiederholt werden.",
 
   "YZECORIOLIS.PrayToIcons": "Zu den Ikonen beten",
   "YZECORIOLIS.PushedRoll": "Wiederholter Wurf",

--- a/lang/de.json
+++ b/lang/de.json
@@ -457,6 +457,16 @@
   "YZECORIOLIS.ItemModifierValue": "Wert des Modifikators",
   "YZECORIOLIS.ItemModifierRollQuestion": "Andere Andere Modifikatoren",
 
-  "YZECORIOLIS.GunnerRollQuestion": "Wer feuert die Waffe ab?"
+  "YZECORIOLIS.GunnerRollQuestion": "Wer feuert die Waffe ab?",
+
+  "YZECORIOLIS.Blessing": "Segnung",
+  "YZECORIOLIS.Blessings": "Segnungen",
+  "YZECORIOLIS.BlessingsAll": "Alle Segnungen",
+  "YZECORIOLIS.Prayer": "Gebet",
+  "YZECORIOLIS.Prayers": "Gebete",
+  "YZECORIOLIS.PrayersAll": "Alle Gebete",
+  "YZECORIOLIS.AttrAll": "Alle Attribute",
+  "YZECORIOLIS.SkillCatGeneralAll": "Alle allgemeinen Fertigkeiten",
+  "YZECORIOLIS.SkillCatAdvancedAll": "Alle fortgeschrittenen Fähigkeiten"
 
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -30,6 +30,7 @@
   "YZECORIOLIS.ErrorsActorNotHasItemForMacro": "Your controlled Actor does not have an item with that name.",
   "YZECORIOLIS.ErrorsNotOwnedItemForMacro": "You can only create macro buttons for owned items.",
   "YZECORIOLIS.ErrorsNoItemForMacro": "You can't make an macro for this element. Only for weapons, explosives and armor.",
+  "YZECORIOLIS.ErrorsAlreadyPushed": "You've already prayed for this roll. You can't pray (reroll) twice for the same roll.",
 
   "YZECORIOLIS.PrayToIcons": "Pray to the Icons",
   "YZECORIOLIS.PushedRoll": "Pushed Roll",

--- a/lang/en.json
+++ b/lang/en.json
@@ -454,5 +454,16 @@
   "YZECORIOLIS.ItemModifierValue": "Value of the Modifier",
   "YZECORIOLIS.ItemModifierRollQuestion": "Other Modifiers",
 
-  "YZECORIOLIS.GunnerRollQuestion": "Who is releasing the weapon?"
+  "YZECORIOLIS.GunnerRollQuestion": "Who is releasing the weapon?",
+
+  "YZECORIOLIS.Blessing": "Blessing",
+  "YZECORIOLIS.Blessings": "Blessings",
+  "YZECORIOLIS.BlessingsAll": "All Blessings",
+  "YZECORIOLIS.Prayer": "Prayer",
+  "YZECORIOLIS.Prayers": "Prayers",
+  "YZECORIOLIS.PrayersAll": "All Prayers",
+  "YZECORIOLIS.AttrAll": "All Attributes",
+  "YZECORIOLIS.SkillCatGeneralAll": "All General Skills",
+  "YZECORIOLIS.SkillCatAdvancedAll": "All Advanced Skills"
+
 }

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1285,6 +1285,344 @@ export class yzecoriolisActor extends Actor {
             checked: false,
             prayer: true
           };
+          sysData.itemModifiers.force[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.PrayersAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.infiltration[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.PrayersAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.manipulation[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.PrayersAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.meleecombat[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.PrayersAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.observation[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.PrayersAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.rangedcombat[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.PrayersAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.survival[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.PrayersAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          // all prayers - advanced skills
+          sysData.itemModifiers.command[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.PrayersAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.culture[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.PrayersAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.datadjinn[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.PrayersAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.medicurgy[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.PrayersAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.mysticpowers[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.PrayersAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.pilot[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.PrayersAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.science[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.PrayersAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.technology[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.PrayersAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+        }
+        // prayer - messenger
+        if (item.system.itemModifiers[key].mod === "itemModifierPrayersMessenger") {
+          sysData.itemModifiers.datadjinn[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Prayer")}: ${game.i18n.localize("YZECORIOLIS.IconMessenger")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.science[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Prayer")}: ${game.i18n.localize("YZECORIOLIS.IconMessenger")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.technology[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Prayer")}: ${game.i18n.localize("YZECORIOLIS.IconMessenger")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+        }
+        // prayer - dancer
+        if (item.system.itemModifiers[key].mod === "itemModifierPrayersDancer") {
+          sysData.itemModifiers.dexterity[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Prayer")}: ${game.i18n.localize("YZECORIOLIS.IconDancer")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.meleecombat[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Prayer")}: ${game.i18n.localize("YZECORIOLIS.IconDancer")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+        }
+        // prayer - gambler
+        if (item.system.itemModifiers[key].mod === "itemModifierPrayersGambler") {
+          sysData.itemModifiers.observation[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Prayer")}: ${game.i18n.localize("YZECORIOLIS.IconGambler")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.pilot[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Prayer")}: ${game.i18n.localize("YZECORIOLIS.IconGambler")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+        }
+        // prayer - deckhand
+        if (item.system.itemModifiers[key].mod === "itemModifierPrayersDeckhand") {
+          sysData.itemModifiers.force[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Prayer")}: ${game.i18n.localize("YZECORIOLIS.IconDeckhand")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+        }
+        // prayer - merchant
+        if (item.system.itemModifiers[key].mod === "itemModifierPrayersMerchant") {
+          sysData.itemModifiers.manipulation[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Prayer")}: ${game.i18n.localize("YZECORIOLIS.IconMerchant")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+        }
+        // prayer - judge
+        if (item.system.itemModifiers[key].mod === "itemModifierPrayersJudge") {
+          sysData.itemModifiers.rangedcombat[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Prayer")}: ${game.i18n.localize("YZECORIOLIS.IconJudge")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.command[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Prayer")}: ${game.i18n.localize("YZECORIOLIS.IconJudge")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+        }
+        // prayer - traveler
+        if (item.system.itemModifiers[key].mod === "itemModifierPrayersTraveler") {
+          sysData.itemModifiers.survival[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Prayer")}: ${game.i18n.localize("YZECORIOLIS.IconTraveler")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.culture[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Prayer")}: ${game.i18n.localize("YZECORIOLIS.IconTraveler")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+        }
+        // prayer - lady of tears
+        if (item.system.itemModifiers[key].mod === "itemModifierPrayersLadyOfTears") {
+          sysData.itemModifiers.medicurgy[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Prayer")}: ${game.i18n.localize("YZECORIOLIS.IconLadyOfTears")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+        }
+        // prayer - faceless one
+        if (item.system.itemModifiers[key].mod === "itemModifierPrayersFacelessOne") {
+          sysData.itemModifiers.infiltration[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Prayer")}: ${game.i18n.localize("YZECORIOLIS.IconFaceless")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
+          sysData.itemModifiers.mysticpowers[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Prayer")}: ${game.i18n.localize("YZECORIOLIS.IconFaceless")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
+          };
         }
       }
     }
@@ -1336,13 +1674,15 @@ export class yzecoriolisActor extends Actor {
     let bonus = 0;
     for (let t of this.items) {
       const tData = t.system.itemModifiers;
-      bonus += Number(Object.keys(tData).reduce((counter,x) => {
-        counter += (tData[x].mod === "itemModifierHP" && (t.type === 'injury' || t.type === 'talent' || t.system.equipped === true))
-          ? tData[x].value
-          : 0;
-          return counter;
-        }
-      , 0));
+      if (tData) {
+        bonus += Number(Object.keys(tData).reduce((counter,x) => {
+          counter += (tData[x].mod === "itemModifierHP" && (t.type === 'injury' || t.type === 'talent' || t.system.equipped === true))
+            ? tData[x].value
+            : 0;
+            return counter;
+          }
+        , 0));
+      }
     }
     return bonus;
   }
@@ -1352,13 +1692,15 @@ export class yzecoriolisActor extends Actor {
     let bonus = 0;
     for (let t of this.items) {
       const tData = t.system.itemModifiers;
-      bonus += Number(Object.keys(tData).reduce((counter,x) => {
-        counter += (tData[x].mod === "itemModifierMP" && (t.type === 'injury' || t.type === 'talent' || t.system.equipped === true))
-          ? tData[x].value
-          : 0;
-          return counter;
-        }
-      , 0));
+      if (tData) {
+        bonus += Number(Object.keys(tData).reduce((counter,x) => {
+          counter += (tData[x].mod === "itemModifierMP" && (t.type === 'injury' || t.type === 'talent' || t.system.equipped === true))
+            ? tData[x].value
+            : 0;
+            return counter;
+          }
+        , 0));
+      }
     }
     return bonus;
   }
@@ -1368,13 +1710,15 @@ export class yzecoriolisActor extends Actor {
     let bonus = 0;
     for (let t of this.items) {
       const tData = t.system.itemModifiers;
-      bonus += Number(Object.keys(tData).reduce((counter,x) => {
-        counter += (tData[x].mod === "itemModifierRad" && (t.type === 'injury' || t.type === 'talent' || t.system.equipped === true))
-          ? tData[x].value
-          : 0;
-          return counter;
-        }
-      , 0));
+      if (tData) {
+        bonus += Number(Object.keys(tData).reduce((counter,x) => {
+          counter += (tData[x].mod === "itemModifierRad" && (t.type === 'injury' || t.type === 'talent' || t.system.equipped === true))
+            ? tData[x].value
+            : 0;
+            return counter;
+          }
+        , 0));
+      }
     }
     return bonus;
   }
@@ -1384,13 +1728,15 @@ export class yzecoriolisActor extends Actor {
     let bonus = 0;
     for (let t of this.items) {
       const tData = t.system.itemModifiers;
-      bonus += Number(Object.keys(tData).reduce((counter,x) => {
-        counter += (tData[x].mod === "itemModifierEnc" && (t.type === 'injury' || t.type === 'talent' || t.system.equipped === true))
-          ? tData[x].value
-          : 0;
-          return counter;
-        }
-      , 0));
+      if (tData) {
+        bonus += Number(Object.keys(tData).reduce((counter,x) => {
+          counter += (tData[x].mod === "itemModifierEnc" && (t.type === 'injury' || t.type === 'talent' || t.system.equipped === true))
+            ? tData[x].value
+            : 0;
+            return counter;
+          }
+        , 0));
+      }
     }
     return bonus;
   }
@@ -1400,13 +1746,15 @@ export class yzecoriolisActor extends Actor {
     let bonus = 0;
     for (let t of this.items) {
       const tData = t.system.itemModifiers;
-      bonus += Number(Object.keys(tData).reduce((counter,x) => {
-        counter += (tData[x].mod === "itemModifierMR" && (t.type === 'injury' || t.type === 'talent' || t.system.equipped === true))
-          ? tData[x].value
-          : 0;
-          return counter;
-        }
-      , 0));
+      if (tData) {
+        bonus += Number(Object.keys(tData).reduce((counter,x) => {
+          counter += (tData[x].mod === "itemModifierMR" && (t.type === 'injury' || t.type === 'talent' || t.system.equipped === true))
+            ? tData[x].value
+            : 0;
+            return counter;
+          }
+        , 0));
+      }
     }
     return bonus;
   }

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -512,6 +512,661 @@ export class yzecoriolisActor extends Actor {
             checked: false
           };
         }
+        // all attributes
+        if (item.system.itemModifiers[key].mod === "itemModifierAttrAll") {
+          sysData.itemModifiers.strength[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.agility[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.wits[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.empathy[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          // all attributes - general skills
+          sysData.itemModifiers.dexterity[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.force[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.infiltration[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.manipulation[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.meleecombat[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.observation[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.rangedcombat[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.survival[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          // all attributes - advanced skills
+          sysData.itemModifiers.command[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.culture[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.datadjinn[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.medicurgy[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.mysticpowers[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.pilot[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.science[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.technology[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: game.i18n.localize("YZECORIOLIS.AttrAll"),
+            skill: null,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+        }
+        // all general skills
+        if (item.system.itemModifiers[key].mod === "itemModifierSkillCatGeneralAll") {
+          sysData.itemModifiers.dexterity[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.SkillCatGeneralAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.force[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.SkillCatGeneralAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.infiltration[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.SkillCatGeneralAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.manipulation[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.SkillCatGeneralAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.meleecombat[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.SkillCatGeneralAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.observation[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.SkillCatGeneralAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.rangedcombat[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.SkillCatGeneralAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.survival[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.SkillCatGeneralAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+        }
+        // all advanced skills
+        if (item.system.itemModifiers[key].mod === "itemModifierSkillCatAdvancedAll") {
+          sysData.itemModifiers.command[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.SkillCatAdvancedAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.culture[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.SkillCatAdvancedAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.datadjinn[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.SkillCatAdvancedAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.medicurgy[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.SkillCatAdvancedAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.mysticpowers[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.SkillCatAdvancedAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.pilot[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.SkillCatAdvancedAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.science[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.SkillCatAdvancedAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.technology[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.SkillCatAdvancedAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+        }
+        // all blessings
+        if (item.system.itemModifiers[key].mod === "itemModifierBlessingsAll") {
+          // all blessings - general skills
+          sysData.itemModifiers.dexterity[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.force[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.infiltration[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.manipulation[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.meleecombat[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.observation[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.rangedcombat[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.survival[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          // all blessings - advanced skills
+          sysData.itemModifiers.command[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.culture[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.datadjinn[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.medicurgy[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.mysticpowers[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.pilot[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.science[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.technology[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+        }
+        // blessing - messenger
+        if (item.system.itemModifiers[key].mod === "itemModifierBlessingsMessenger") {
+          sysData.itemModifiers.datadjinn[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconMessenger")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.science[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconMessenger")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.technology[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconMessenger")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+        }
+        // blessing - dancer
+        if (item.system.itemModifiers[key].mod === "itemModifierBlessingsDancer") {
+          sysData.itemModifiers.dexterity[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconDancer")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.meleecombat[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconDancer")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+        }
+        // blessing - gambler
+        if (item.system.itemModifiers[key].mod === "itemModifierBlessingsGambler") {
+          sysData.itemModifiers.observation[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconGambler")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.pilot[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconGambler")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+        }
+        // blessing - deckhand
+        if (item.system.itemModifiers[key].mod === "itemModifierBlessingsDeckhand") {
+          sysData.itemModifiers.force[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconDeckhand")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+        }
+        // blessing - merchant
+        if (item.system.itemModifiers[key].mod === "itemModifierBlessingsMerchant") {
+          sysData.itemModifiers.manipulation[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconMerchant")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+        }
+        // blessing - judge
+        if (item.system.itemModifiers[key].mod === "itemModifierBlessingsJudge") {
+          sysData.itemModifiers.rangedcombat[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconJudge")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.command[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconJudge")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+        }
+        // blessing - traveler
+        if (item.system.itemModifiers[key].mod === "itemModifierBlessingsTraveler") {
+          sysData.itemModifiers.survival[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconTraveler")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.culture[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconTraveler")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+        }
+        // blessing - lady of tears
+        if (item.system.itemModifiers[key].mod === "itemModifierBlessingsLadyOfTears") {
+          sysData.itemModifiers.medicurgy[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconLadyOfTears")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+        }
+        // blessing - faceless one
+        if (item.system.itemModifiers[key].mod === "itemModifierBlessingsFacelessOne") {
+          sysData.itemModifiers.infiltration[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconFaceless")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+          sysData.itemModifiers.mysticpowers[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconFaceless")}`,
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false
+          };
+        }
       }
     }
 

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -141,7 +141,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.force[key] = {
             id: key,
@@ -150,7 +151,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.meleecombat[key] = {
             id: key,
@@ -159,7 +161,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         if (item.system.itemModifiers[key].mod === "itemModifierSkillForce") {
@@ -170,7 +173,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillForce"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         if (item.system.itemModifiers[key].mod === "itemModifierSkillMelee") {
@@ -181,7 +185,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillMeleeCombat"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         // everything with the agility-attribute
@@ -193,7 +198,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.dexterity[key] = {
             id: key,
@@ -202,7 +208,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.infiltration[key] = {
             id: key,
@@ -211,7 +218,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.rangedcombat[key] = {
             id: key,
@@ -220,7 +228,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.pilot[key] = {
             id: key,
@@ -229,7 +238,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         if (item.system.itemModifiers[key].mod === "itemModifierSkillDex") {
@@ -240,7 +250,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillDexterity"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         if (item.system.itemModifiers[key].mod === "itemModifierSkillInf") {
@@ -251,7 +262,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillInfiltration"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         if (item.system.itemModifiers[key].mod === "itemModifierSkillRange") {
@@ -262,7 +274,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillRangedCombat"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         if (item.system.itemModifiers[key].mod === "itemModifierSkillPil") {
@@ -273,7 +286,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillPilot"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         // everything with the wits-attribute
@@ -285,7 +299,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.observation[key] = {
             id: key,
@@ -294,7 +309,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.survival[key] = {
             id: key,
@@ -303,7 +319,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.datadjinn[key] = {
             id: key,
@@ -312,7 +329,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.medicurgy[key] = {
             id: key,
@@ -321,7 +339,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.science[key] = {
             id: key,
@@ -330,7 +349,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.technology[key] = {
             id: key,
@@ -339,7 +359,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         if (item.system.itemModifiers[key].mod === "itemModifierSkillObs") {
@@ -350,7 +371,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillObservation"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         if (item.system.itemModifiers[key].mod === "itemModifierSkillSurv") {
@@ -361,7 +383,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillSurvival"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         if (item.system.itemModifiers[key].mod === "itemModifierSkillData") {
@@ -372,7 +395,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillDataDjinn"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         if (item.system.itemModifiers[key].mod === "itemModifierSkillMedi") {
@@ -383,7 +407,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillMedicurgy"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         if (item.system.itemModifiers[key].mod === "itemModifierSkillSci") {
@@ -394,7 +419,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillScience"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         if (item.system.itemModifiers[key].mod === "itemModifierSkillTech") {
@@ -405,7 +431,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillTechnology"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         // everything with the empathy-attribute
@@ -417,7 +444,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.manipulation[key] = {
             id: key,
@@ -426,7 +454,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.command[key] = {
             id: key,
@@ -435,7 +464,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.culture[key] = {
             id: key,
@@ -444,7 +474,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.mysticpowers[key] = {
             id: key,
@@ -453,7 +484,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         if (item.system.itemModifiers[key].mod === "itemModifierSkillMan") {
@@ -464,7 +496,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillManipulation"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         if (item.system.itemModifiers[key].mod === "itemModifierSkillCom") {
@@ -475,7 +508,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCommand"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         if (item.system.itemModifiers[key].mod === "itemModifierSkillCult") {
@@ -486,7 +520,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCulture"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         if (item.system.itemModifiers[key].mod === "itemModifierSkillMys") {
@@ -497,7 +532,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillMysticPowers"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         // other roll related modifiers
@@ -509,7 +545,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         // all attributes
@@ -521,7 +558,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.agility[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -530,7 +568,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.wits[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -539,7 +578,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.empathy[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -548,7 +588,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           // all attributes - general skills
           sysData.itemModifiers.dexterity[`${key}|${item._id}`] = {
@@ -558,7 +599,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.force[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -567,7 +609,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.infiltration[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -576,7 +619,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.manipulation[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -585,7 +629,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.meleecombat[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -594,7 +639,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.observation[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -603,7 +649,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.rangedcombat[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -612,7 +659,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.survival[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -621,7 +669,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           // all attributes - advanced skills
           sysData.itemModifiers.command[`${key}|${item._id}`] = {
@@ -631,7 +680,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.culture[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -640,7 +690,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.datadjinn[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -649,7 +700,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.medicurgy[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -658,7 +710,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.mysticpowers[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -667,7 +720,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.pilot[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -676,7 +730,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.science[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -685,7 +740,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.technology[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -694,7 +750,8 @@ export class yzecoriolisActor extends Actor {
             skill: null,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         // all general skills
@@ -706,7 +763,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCatGeneralAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.force[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -715,7 +773,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCatGeneralAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.infiltration[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -724,7 +783,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCatGeneralAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.manipulation[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -733,7 +793,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCatGeneralAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.meleecombat[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -742,7 +803,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCatGeneralAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.observation[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -751,7 +813,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCatGeneralAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.rangedcombat[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -760,7 +823,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCatGeneralAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.survival[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -769,7 +833,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCatGeneralAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         // all advanced skills
@@ -781,7 +846,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCatAdvancedAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.culture[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -790,7 +856,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCatAdvancedAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.datadjinn[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -799,7 +866,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCatAdvancedAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.medicurgy[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -808,7 +876,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCatAdvancedAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.mysticpowers[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -817,7 +886,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCatAdvancedAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.pilot[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -826,7 +896,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCatAdvancedAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.science[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -835,7 +906,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCatAdvancedAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.technology[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -844,7 +916,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.SkillCatAdvancedAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         // all blessings
@@ -857,7 +930,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.force[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -866,7 +940,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.infiltration[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -875,7 +950,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.manipulation[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -884,7 +960,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.meleecombat[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -893,7 +970,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.observation[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -902,7 +980,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.rangedcombat[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -911,7 +990,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.survival[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -920,7 +1000,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           // all blessings - advanced skills
           sysData.itemModifiers.command[`${key}|${item._id}`] = {
@@ -930,7 +1011,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.culture[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -939,7 +1021,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.datadjinn[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -948,7 +1031,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.medicurgy[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -957,7 +1041,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.mysticpowers[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -966,7 +1051,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.pilot[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -975,7 +1061,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.science[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -984,7 +1071,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.technology[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -993,7 +1081,8 @@ export class yzecoriolisActor extends Actor {
             skill: game.i18n.localize("YZECORIOLIS.BlessingsAll"),
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         // blessing - messenger
@@ -1005,7 +1094,8 @@ export class yzecoriolisActor extends Actor {
             skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconMessenger")}`,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.science[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -1014,7 +1104,8 @@ export class yzecoriolisActor extends Actor {
             skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconMessenger")}`,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.technology[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -1023,7 +1114,8 @@ export class yzecoriolisActor extends Actor {
             skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconMessenger")}`,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         // blessing - dancer
@@ -1035,7 +1127,8 @@ export class yzecoriolisActor extends Actor {
             skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconDancer")}`,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.meleecombat[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -1044,7 +1137,8 @@ export class yzecoriolisActor extends Actor {
             skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconDancer")}`,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         // blessing - gambler
@@ -1056,7 +1150,8 @@ export class yzecoriolisActor extends Actor {
             skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconGambler")}`,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.pilot[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -1065,7 +1160,8 @@ export class yzecoriolisActor extends Actor {
             skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconGambler")}`,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         // blessing - deckhand
@@ -1077,7 +1173,8 @@ export class yzecoriolisActor extends Actor {
             skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconDeckhand")}`,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         // blessing - merchant
@@ -1089,7 +1186,8 @@ export class yzecoriolisActor extends Actor {
             skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconMerchant")}`,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         // blessing - judge
@@ -1101,7 +1199,8 @@ export class yzecoriolisActor extends Actor {
             skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconJudge")}`,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.command[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -1110,7 +1209,8 @@ export class yzecoriolisActor extends Actor {
             skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconJudge")}`,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         // blessing - traveler
@@ -1122,7 +1222,8 @@ export class yzecoriolisActor extends Actor {
             skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconTraveler")}`,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.culture[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -1131,7 +1232,8 @@ export class yzecoriolisActor extends Actor {
             skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconTraveler")}`,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         // blessing - lady of tears
@@ -1143,7 +1245,8 @@ export class yzecoriolisActor extends Actor {
             skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconLadyOfTears")}`,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
         }
         // blessing - faceless one
@@ -1155,7 +1258,8 @@ export class yzecoriolisActor extends Actor {
             skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconFaceless")}`,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
           };
           sysData.itemModifiers.mysticpowers[`${key}|${item._id}`] = {
             id: `${key}|${item._id}`,
@@ -1164,7 +1268,22 @@ export class yzecoriolisActor extends Actor {
             skill: `${game.i18n.localize("YZECORIOLIS.Blessing")}: ${game.i18n.localize("YZECORIOLIS.IconFaceless")}`,
             type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
             value: item.system.itemModifiers[key].value,
-            checked: false
+            checked: false,
+            prayer: false
+          };
+        }
+        // all prayers
+        if (item.system.itemModifiers[key].mod === "itemModifierPrayersAll") {
+          // all prayers - general skills
+          sysData.itemModifiers.dexterity[`${key}|${item._id}`] = {
+            id: `${key}|${item._id}`,
+            name: item.name,
+            attribute: null,
+            skill: game.i18n.localize("YZECORIOLIS.PrayersAll"),
+            type: game.i18n.localize(CONFIG.YZECORIOLIS.itemTypes[item.type]),
+            value: item.system.itemModifiers[key].value,
+            checked: false,
+            prayer: true
           };
         }
       }

--- a/module/coriolisPrayerModifier.js
+++ b/module/coriolisPrayerModifier.js
@@ -11,9 +11,6 @@ export class CoriolisModifierDialog extends FormApplication {
         for (let mod in origRollData.itemModifiers) {
           if (origRollData.itemModifiers[mod].prayer) {
             this.itemModifiers[mod] = origRollData.itemModifiers[mod];
-            // set prayer to false
-            // otherwise it won't parse through roll-itemModifiers.html
-            this.itemModifiers[mod].prayer = false;
           }
         }
       }
@@ -38,10 +35,10 @@ export class CoriolisModifierDialog extends FormApplication {
     
     getData() {
       // Send data to the template
-        return {
-          prayerRoll: true,
-          itemModifiers: this.itemModifiers,
-        };
+      return {
+        prayerRoll: true,
+        itemModifiers: this.itemModifiers,
+      };
     }
   
     activateListeners(html) {

--- a/module/coriolisPrayerModifier.js
+++ b/module/coriolisPrayerModifier.js
@@ -1,0 +1,75 @@
+import { coriolisPushRoll } from "./coriolis-roll.js";
+
+export class CoriolisModifierDialog extends FormApplication {
+    constructor(chatMessage, origRollData, origRoll) {
+      super();
+      this.chatMessage = chatMessage;
+      this.origRollData = origRollData;
+      this.origRoll = origRoll;
+      this.itemModifiers = {};
+      if (origRollData.rollType != 'attribute' && origRollData.rollType != 'armor') {
+        for (let mod in origRollData.itemModifiers) {
+          if (origRollData.itemModifiers[mod].prayer) {
+            this.itemModifiers[mod] = origRollData.itemModifiers[mod];
+            // set prayer to false
+            // otherwise it won't parse through roll-itemModifiers.html
+            this.itemModifiers[mod].prayer = false;
+          }
+        }
+      }
+    }
+  
+    static get defaultOptions() {
+      return mergeObject(super.defaultOptions, {
+        classes: ['form'],
+        popOut: true,
+        template: "systems/yzecoriolis/templates/dialog/coriolis-roll.html",
+        id: 'coriolisModifierDialog',
+        title: game.i18n.localize("YZECORIOLIS.ModifierForRoll"),
+        height: 'auto',
+        width: 'auto',
+        minimizable: false,
+        resizable: true,
+        closeOnSubmit: true,
+        submitOnClose: false,
+        submitOnChange: false,
+      });
+    }
+    
+    getData() {
+      // Send data to the template
+        return {
+          prayerRoll: true,
+          itemModifiers: this.itemModifiers,
+        };
+    }
+  
+    activateListeners(html) {
+      super.activateListeners(html);
+    }
+
+    async _onChangeInput(event) {    
+      if (event.currentTarget.name.match(/^si_.*$/)) {
+        this.itemModifiers[event.currentTarget.name].checked = event.currentTarget.checked;
+      }
+      this.render();
+    }
+
+    async _updateObject(event, formData) {
+      this.origRollData.prayerBonus = parseInt(event.submitter.value);
+      this.origRollData.prayerModifiersBonus = 0;
+      this.origRollData.prayerModifiers = {};
+      for (const modifier in this.itemModifiers) {
+        if (this.itemModifiers[modifier].checked) {
+          this.origRollData.prayerModifiersBonus += parseInt(this.itemModifiers[modifier].value);
+          this.origRollData.prayerModifiers[modifier] = this.itemModifiers[modifier];
+          // uncheck them, so that they don't get listet as regular itemModfiers
+          this.itemModifiers[modifier].checked = false;
+        }
+      }
+      coriolisPushRoll(this.chatMessage, this.origRollData, this.origRoll);
+      return;
+    }
+  }
+  
+  window.CoriolisModifierDialog = CoriolisModifierDialog;

--- a/templates/dialog/roll-itemModifiers.html
+++ b/templates/dialog/roll-itemModifiers.html
@@ -1,10 +1,20 @@
 <div style="padding: 1em 1em;">
   <h3>{{localize "YZECORIOLIS.ItemModifierRollQuestion"}}</h3>
-  {{#each itemModifiers as |mod|}}
-    {{#unless mod.prayer}}
-      <input type='checkbox' name={{mod.id}} {{#if mod.checked}}checked{{/if}} data-dtype='Boolean' />
-      <label style="position:relative; bottom:6px;">{{mod.type}}: {{mod.name}} ({{#if_gt mod.value 0}}+{{mod.value}}{{else}}{{mod.value}}{{/if_gt}} {{#if mod.skill}}{{mod.skill}}{{else}}{{mod.attribute}}{{/if}})</label>
-      <br>
-    {{/unless}}
-  {{/each}}
+  {{#if prayerRoll}}
+    {{#each itemModifiers as |mod|}}
+      {{#if mod.prayer}}
+        <input type='checkbox' name={{mod.id}} {{#if mod.checked}}checked{{/if}} data-dtype='Boolean' />
+        <label style="position:relative; bottom:6px;">{{mod.type}}: {{mod.name}} ({{#if_gt mod.value 0}}+{{mod.value}}{{else}}{{mod.value}}{{/if_gt}} {{#if mod.skill}}{{mod.skill}}{{else}}{{mod.attribute}}{{/if}})</label>
+        <br>
+      {{/if}}
+    {{/each}}
+  {{else}}
+    {{#each itemModifiers as |mod|}}
+      {{#unless mod.prayer}}
+        <input type='checkbox' name={{mod.id}} {{#if mod.checked}}checked{{/if}} data-dtype='Boolean' />
+        <label style="position:relative; bottom:6px;">{{mod.type}}: {{mod.name}} ({{#if_gt mod.value 0}}+{{mod.value}}{{else}}{{mod.value}}{{/if_gt}} {{#if mod.skill}}{{mod.skill}}{{else}}{{mod.attribute}}{{/if}})</label>
+        <br>
+      {{/unless}}
+    {{/each}}
+  {{/if}}
 </div>

--- a/templates/dialog/roll-itemModifiers.html
+++ b/templates/dialog/roll-itemModifiers.html
@@ -1,8 +1,10 @@
 <div style="padding: 1em 1em;">
   <h3>{{localize "YZECORIOLIS.ItemModifierRollQuestion"}}</h3>
   {{#each itemModifiers as |mod|}}
-    <input type='checkbox' name={{mod.id}} {{#if mod.checked}}checked{{/if}} data-dtype='Boolean' />
-    <label style="position:relative; bottom:6px;">{{mod.type}}: {{mod.name}} ({{#if_gt mod.value 0}}+{{mod.value}}{{else}}{{mod.value}}{{/if_gt}} {{#if mod.skill}}{{mod.skill}}{{else}}{{mod.attribute}}{{/if}})</label>
-    <br>
+    {{#unless mod.prayer}}
+      <input type='checkbox' name={{mod.id}} {{#if mod.checked}}checked{{/if}} data-dtype='Boolean' />
+      <label style="position:relative; bottom:6px;">{{mod.type}}: {{mod.name}} ({{#if_gt mod.value 0}}+{{mod.value}}{{else}}{{mod.value}}{{/if_gt}} {{#if mod.skill}}{{mod.skill}}{{else}}{{mod.attribute}}{{/if}})</label>
+      <br>
+    {{/unless}}
   {{/each}}
 </div>

--- a/templates/dialog/roll-modifiers.html
+++ b/templates/dialog/roll-modifiers.html
@@ -1,24 +1,33 @@
-<div style="padding: 1em 1em;">
-    <h3>{{localize "YZECORIOLIS.ModifierForRollQuestion"}}</h3>
-    <button type="submit" value="-9" style="width: 3em;">-9</button>
-    <button type="submit" value="-8" style="width: 3em;">-8</button>
-    <button type="submit" value="-7" style="width: 3em;">-7</button>
-    <button type="submit" value="-6" style="width: 3em;">-6</button>
-    <button type="submit" value="-5" style="width: 3em;">-5</button>
-    <button type="submit" value="-4" style="width: 3em;">-4</button>
-    <button type="submit" value="-3" style="width: 3em;">-3</button>
-    <button type="submit" value="-2" style="width: 3em;">-2</button>
-    <button type="submit" value="-1" style="width: 3em;">-1</button>
-    <br>
-    <button type="submit" value="0" style="width: 30.25em; margin: 0.5em 0;">±0</button>
-    <br>
-    <button type="submit" value="1" style="width: 3em;">+1</button>
-    <button type="submit" value="2" style="width: 3em;">+2</button>
-    <button type="submit" value="3" style="width: 3em;">+3</button>
-    <button type="submit" value="4" style="width: 3em;">+4</button>
-    <button type="submit" value="5" style="width: 3em;">+5</button>
-    <button type="submit" value="6" style="width: 3em;">+6</button>
-    <button type="submit" value="7" style="width: 3em;">+7</button>
-    <button type="submit" value="8" style="width: 3em;">+8</button>
-    <button type="submit" value="9" style="width: 3em;">+9</button>
-</div>
+{{#if prayerRoll}}
+    <div style="padding: 1em 1em;">
+        <h3>{{localize "YZECORIOLIS.PrayerModifierForRollQuestion"}}</h3>
+        <button type="submit" value="0" style="width: 5em;">0</button>
+        <button type="submit" value="1" style="width: 5em;">+1</button>
+        <button type="submit" value="2" style="width: 5em;">+2</button>
+    </div>
+{{else}}
+    <div style="padding: 1em 1em;">
+        <h3>{{localize "YZECORIOLIS.ModifierForRollQuestion"}}</h3>
+        <button type="submit" value="-9" style="width: 3em;">-9</button>
+        <button type="submit" value="-8" style="width: 3em;">-8</button>
+        <button type="submit" value="-7" style="width: 3em;">-7</button>
+        <button type="submit" value="-6" style="width: 3em;">-6</button>
+        <button type="submit" value="-5" style="width: 3em;">-5</button>
+        <button type="submit" value="-4" style="width: 3em;">-4</button>
+        <button type="submit" value="-3" style="width: 3em;">-3</button>
+        <button type="submit" value="-2" style="width: 3em;">-2</button>
+        <button type="submit" value="-1" style="width: 3em;">-1</button>
+        <br>
+        <button type="submit" value="0" style="width: 30.25em; margin: 0.5em 0;">±0</button>
+        <br>
+        <button type="submit" value="1" style="width: 3em;">+1</button>
+        <button type="submit" value="2" style="width: 3em;">+2</button>
+        <button type="submit" value="3" style="width: 3em;">+3</button>
+        <button type="submit" value="4" style="width: 3em;">+4</button>
+        <button type="submit" value="5" style="width: 3em;">+5</button>
+        <button type="submit" value="6" style="width: 3em;">+6</button>
+        <button type="submit" value="7" style="width: 3em;">+7</button>
+        <button type="submit" value="8" style="width: 3em;">+8</button>
+        <button type="submit" value="9" style="width: 3em;">+9</button>
+    </div>
+{{/if}}

--- a/templates/item/modifiers.html
+++ b/templates/item/modifiers.html
@@ -16,7 +16,7 @@
                     <option value="itemModifierNone" disabled  selected>{{localize "YZECORIOLIS.ItemModifierSelect"}}</option>
                     <optgroup label={{localize "YZECORIOLIS.Attributes"}}>
                       <option value="itemModifierAttrAll">{{localize "YZECORIOLIS.AttrAll"}}</option>
-                      <option value="itemModifierAttrStrength">{{localize "YZECORIOLIS.AttrStrength"}}</this></option>
+                      <option value="itemModifierAttrStrength">{{localize "YZECORIOLIS.AttrStrength"}}</option>
                       <option value="itemModifierAttrAgility">{{localize "YZECORIOLIS.AttrAgility"}}</option>
                       <option value="itemModifierAttrWits">{{localize "YZECORIOLIS.AttrWits"}}</option>
                       <option value="itemModifierAttrEmpathy">{{localize "YZECORIOLIS.AttrEmpathy"}}</option>

--- a/templates/item/modifiers.html
+++ b/templates/item/modifiers.html
@@ -14,14 +14,14 @@
                 <select name="system.itemModifiers.{{id}}.mod">
                     {{#select itemmod.mod}}
                     <option value="itemModifierNone" disabled  selected>{{localize "YZECORIOLIS.ItemModifierSelect"}}</option>
-                    <optgroup label="{{localize "YZECORIOLIS.Attributes"}}">
+                    <optgroup label={{localize "YZECORIOLIS.Attributes"}}>
                       <option value="itemModifierAttrAll">{{localize "YZECORIOLIS.AttrAll"}}</option>
-                      <option value="itemModifierAttrStrength">{{localize "YZECORIOLIS.AttrStrength"}}</option>
+                      <option value="itemModifierAttrStrength">{{localize "YZECORIOLIS.AttrStrength"}}</this></option>
                       <option value="itemModifierAttrAgility">{{localize "YZECORIOLIS.AttrAgility"}}</option>
                       <option value="itemModifierAttrWits">{{localize "YZECORIOLIS.AttrWits"}}</option>
                       <option value="itemModifierAttrEmpathy">{{localize "YZECORIOLIS.AttrEmpathy"}}</option>
                     </optgroup>
-                    <optgroup label="{{localize "YZECORIOLIS.SkillCatGeneral"}}">
+                    <optgroup label={{localize "YZECORIOLIS.SkillCatGeneral"}}>
                       <option value="itemModifierSkillCatGeneralAll">{{localize "YZECORIOLIS.SkillCatGeneralAll"}}</option>
                       <option value="itemModifierSkillDex">{{localize "YZECORIOLIS.SkillDexterity"}}</option>
                       <option value="itemModifierSkillForce">{{localize "YZECORIOLIS.SkillForce"}}</option>
@@ -32,7 +32,7 @@
                       <option value="itemModifierSkillRange">{{localize "YZECORIOLIS.SkillRangedCombat"}}</option>
                       <option value="itemModifierSkillSurv">{{localize "YZECORIOLIS.SkillSurvival"}}</option>
                     </optgroup>
-                    <optgroup label="{{localize "YZECORIOLIS.SkillCatAdvanced"}}">
+                    <optgroup label={{localize "YZECORIOLIS.SkillCatAdvanced"}}>
                       <option value="itemModifierSkillCatAdvancedAll">{{localize "YZECORIOLIS.SkillCatAdvancedAll"}}</option>
                       <option value="itemModifierSkillCom">{{localize "YZECORIOLIS.SkillCommand"}}</option>
                       <option value="itemModifierSkillCult">{{localize "YZECORIOLIS.SkillCulture"}}</option>
@@ -43,31 +43,31 @@
                       <option value="itemModifierSkillSci">{{localize "YZECORIOLIS.SkillScience"}}</option>
                       <option value="itemModifierSkillTech">{{localize "YZECORIOLIS.SkillTechnology"}}</option>
                     </optgroup>
-                    <optgroup label="{{localize "YZECORIOLIS.Blessings"}}">
+                    <optgroup label={{localize "YZECORIOLIS.Blessings"}}>
                       <option value="itemModifierBlessingsAll">{{localize "YZECORIOLIS.BlessingsAll"}}</option>
-                      <option value="itemModifierBlessingsMessenger">{{localize "YZECORIOLIS.IconMessenger"}}</option>
-                      <option value="itemModifierBlessingsDancer">{{localize "YZECORIOLIS.IconDancer"}}</option>
-                      <option value="itemModifierBlessingsGambler">{{localize "YZECORIOLIS.IconGambler"}}</option>
-                      <option value="itemModifierBlessingsDeckhand">{{localize "YZECORIOLIS.IconDeckhand"}}</option>
-                      <option value="itemModifierBlessingsMerchant">{{localize "YZECORIOLIS.IconMerchant"}}</option>
-                      <option value="itemModifierBlessingsJudge">{{localize "YZECORIOLIS.IconJudge"}}</option>
-                      <option value="itemModifierBlessingsTraveler">{{localize "YZECORIOLIS.IconTraveler"}}</option>
-                      <option value="itemModifierBlessingsLadyOfTears">{{localize "YZECORIOLIS.IconLadyOfTears"}}</option>
-                      <option value="itemModifierBlessingsFacelessOne">{{localize "YZECORIOLIS.IconFaceless"}}</option>
+                      <option value="itemModifierBlessingsMessenger">{{localize "YZECORIOLIS.IconMessenger"}} {{#if_eq this.mod "itemModifierBlessingsMessenger"}}({{localize "YZECORIOLIS.Blessing"}}){{/if_eq}}</option>
+                      <option value="itemModifierBlessingsDancer">{{localize "YZECORIOLIS.IconDancer"}} {{#if_eq this.mod "itemModifierBlessingsDancer"}}({{localize "YZECORIOLIS.Blessing"}}){{/if_eq}}</option>
+                      <option value="itemModifierBlessingsGambler">{{localize "YZECORIOLIS.IconGambler"}} {{#if_eq this.mod "itemModifierBlessingsGambler"}}({{localize "YZECORIOLIS.Blessing"}}){{/if_eq}}</option>
+                      <option value="itemModifierBlessingsDeckhand">{{localize "YZECORIOLIS.IconDeckhand"}} {{#if_eq this.mod "itemModifierBlessingsDeckhand"}}({{localize "YZECORIOLIS.Blessing"}}){{/if_eq}}</option>
+                      <option value="itemModifierBlessingsMerchant">{{localize "YZECORIOLIS.IconMerchant"}} {{#if_eq this.mod "itemModifierBlessingsMerchant"}}({{localize "YZECORIOLIS.Blessing"}}){{/if_eq}}</option>
+                      <option value="itemModifierBlessingsJudge">{{localize "YZECORIOLIS.IconJudge"}} {{#if_eq this.mod "itemModifierBlessingsJudge"}}({{localize "YZECORIOLIS.Blessing"}}){{/if_eq}}</option>
+                      <option value="itemModifierBlessingsTraveler">{{localize "YZECORIOLIS.IconTraveler"}} {{#if_eq this.mod "itemModifierBlessingsTraveler"}}({{localize "YZECORIOLIS.Blessing"}}){{/if_eq}}</option>
+                      <option value="itemModifierBlessingsLadyOfTears">{{localize "YZECORIOLIS.IconLadyOfTears"}} {{#if_eq this.mod "itemModifierBlessingsLadyOfTears"}}({{localize "YZECORIOLIS.Blessing"}}){{/if_eq}}</option>
+                      <option value="itemModifierBlessingsFacelessOne">{{localize "YZECORIOLIS.IconFaceless"}} {{#if_eq this.mod "itemModifierBlessingsFacelessOne"}}({{localize "YZECORIOLIS.Blessing"}}){{/if_eq}}</option>
                     </optgroup>
-                    <optgroup label="{{localize "YZECORIOLIS.Prayers"}}">
+                    <optgroup label={{localize "YZECORIOLIS.Prayers"}}>
                       <option value="itemModifierPrayersAll">{{localize "YZECORIOLIS.PrayersAll"}}</option>
-                      <option value="itemModifierPrayersMessenger">{{localize "YZECORIOLIS.IconMessenger"}}</option>
-                      <option value="itemModifierPrayersDancer">{{localize "YZECORIOLIS.IconDancer"}}</option>
-                      <option value="itemModifierPrayersGambler">{{localize "YZECORIOLIS.IconGambler"}}</option>
-                      <option value="itemModifierPrayersDeckhand">{{localize "YZECORIOLIS.IconDeckhand"}}</option>
-                      <option value="itemModifierPrayersMerchant">{{localize "YZECORIOLIS.IconMerchant"}}</option>
-                      <option value="itemModifierPrayersJudge">{{localize "YZECORIOLIS.IconJudge"}}</option>
-                      <option value="itemModifierPrayersTraveler">{{localize "YZECORIOLIS.IconTraveler"}}</option>
-                      <option value="itemModifierPrayersLadyOfTears">{{localize "YZECORIOLIS.IconLadyOfTears"}}</option>
-                      <option value="itemModifierPrayersFacelessOne">{{localize "YZECORIOLIS.IconFaceless"}}</option>
+                      <option value="itemModifierPrayersMessenger">{{localize "YZECORIOLIS.IconMessenger"}} {{#if_eq this.mod "itemModifierPrayersMessenger"}}({{localize "YZECORIOLIS.Prayer"}}){{/if_eq}}</option>
+                      <option value="itemModifierPrayersDancer">{{localize "YZECORIOLIS.IconDancer"}} {{#if_eq this.mod "itemModifierPrayersDancer"}}({{localize "YZECORIOLIS.Prayer"}}){{/if_eq}}</option>
+                      <option value="itemModifierPrayersGambler">{{localize "YZECORIOLIS.IconGambler"}} {{#if_eq this.mod "itemModifierPrayersGambler"}}({{localize "YZECORIOLIS.Prayer"}}){{/if_eq}}</option>
+                      <option value="itemModifierPrayersDeckhand">{{localize "YZECORIOLIS.IconDeckhand"}} {{#if_eq this.mod "itemModifierPrayersDeckhand"}}({{localize "YZECORIOLIS.Prayer"}}){{/if_eq}}</option>
+                      <option value="itemModifierPrayersMerchant">{{localize "YZECORIOLIS.IconMerchant"}} {{#if_eq this.mod "itemModifierPrayersMerchant"}}({{localize "YZECORIOLIS.Prayer"}}){{/if_eq}}</option>
+                      <option value="itemModifierPrayersJudge">{{localize "YZECORIOLIS.IconJudge"}} {{#if_eq this.mod "itemModifierPrayersJudge"}}({{localize "YZECORIOLIS.Prayer"}}){{/if_eq}}</option>
+                      <option value="itemModifierPrayersTraveler">{{localize "YZECORIOLIS.IconTraveler"}} {{#if_eq this.mod "itemModifierPrayersTraveler"}}({{localize "YZECORIOLIS.Prayer"}}){{/if_eq}}</option>
+                      <option value="itemModifierPrayersLadyOfTears">{{localize "YZECORIOLIS.IconLadyOfTears"}} {{#if_eq this.mod "itemModifierPrayersLadyOfTears"}}({{localize "YZECORIOLIS.Prayer"}}){{/if_eq}}</option>
+                      <option value="itemModifierPrayersFacelessOne">{{localize "YZECORIOLIS.IconFaceless"}} {{#if_eq this.mod "itemModifierPrayersFacelessOne"}}({{localize "YZECORIOLIS.Prayer"}}){{/if_eq}}</option>
                     </optgroup>
-                    <optgroup label="{{localize "YZECORIOLIS.Other"}}">
+                    <optgroup label={{localize "YZECORIOLIS.Other"}}>
                       <option value="itemModifierHP">{{localize "YZECORIOLIS.HitPoints"}}</option>
                       <option value="itemModifierMP">{{localize "YZECORIOLIS.MindPoints"}}</option>
                       <option value="itemModifierArmor">{{localize "YZECORIOLIS.Armor"}}</option>

--- a/templates/item/modifiers.html
+++ b/templates/item/modifiers.html
@@ -15,12 +15,14 @@
                     {{#select itemmod.mod}}
                     <option value="itemModifierNone" disabled  selected>{{localize "YZECORIOLIS.ItemModifierSelect"}}</option>
                     <optgroup label="{{localize "YZECORIOLIS.Attributes"}}">
+                      <option value="itemModifierAttrAll">{{localize "YZECORIOLIS.AttrAll"}}</option>
                       <option value="itemModifierAttrStrength">{{localize "YZECORIOLIS.AttrStrength"}}</option>
                       <option value="itemModifierAttrAgility">{{localize "YZECORIOLIS.AttrAgility"}}</option>
                       <option value="itemModifierAttrWits">{{localize "YZECORIOLIS.AttrWits"}}</option>
                       <option value="itemModifierAttrEmpathy">{{localize "YZECORIOLIS.AttrEmpathy"}}</option>
                     </optgroup>
                     <optgroup label="{{localize "YZECORIOLIS.SkillCatGeneral"}}">
+                      <option value="itemModifierSkillCatGeneralAll">{{localize "YZECORIOLIS.SkillCatGeneralAll"}}</option>
                       <option value="itemModifierSkillDex">{{localize "YZECORIOLIS.SkillDexterity"}}</option>
                       <option value="itemModifierSkillForce">{{localize "YZECORIOLIS.SkillForce"}}</option>
                       <option value="itemModifierSkillInf">{{localize "YZECORIOLIS.SkillInfiltration"}}</option>
@@ -31,6 +33,7 @@
                       <option value="itemModifierSkillSurv">{{localize "YZECORIOLIS.SkillSurvival"}}</option>
                     </optgroup>
                     <optgroup label="{{localize "YZECORIOLIS.SkillCatAdvanced"}}">
+                      <option value="itemModifierSkillCatAdvancedAll">{{localize "YZECORIOLIS.SkillCatAdvancedAll"}}</option>
                       <option value="itemModifierSkillCom">{{localize "YZECORIOLIS.SkillCommand"}}</option>
                       <option value="itemModifierSkillCult">{{localize "YZECORIOLIS.SkillCulture"}}</option>
                       <option value="itemModifierSkillData">{{localize "YZECORIOLIS.SkillDataDjinn"}}</option>
@@ -39,6 +42,30 @@
                       <option value="itemModifierSkillPil">{{localize "YZECORIOLIS.SkillPilot"}}</option>
                       <option value="itemModifierSkillSci">{{localize "YZECORIOLIS.SkillScience"}}</option>
                       <option value="itemModifierSkillTech">{{localize "YZECORIOLIS.SkillTechnology"}}</option>
+                    </optgroup>
+                    <optgroup label="{{localize "YZECORIOLIS.Blessings"}}">
+                      <option value="itemModifierBlessingsAll">{{localize "YZECORIOLIS.BlessingsAll"}}</option>
+                      <option value="itemModifierBlessingsMessenger">{{localize "YZECORIOLIS.IconMessenger"}}</option>
+                      <option value="itemModifierBlessingsDancer">{{localize "YZECORIOLIS.IconDancer"}}</option>
+                      <option value="itemModifierBlessingsGambler">{{localize "YZECORIOLIS.IconGambler"}}</option>
+                      <option value="itemModifierBlessingsDeckhand">{{localize "YZECORIOLIS.IconDeckhand"}}</option>
+                      <option value="itemModifierBlessingsMerchant">{{localize "YZECORIOLIS.IconMerchant"}}</option>
+                      <option value="itemModifierBlessingsJudge">{{localize "YZECORIOLIS.IconJudge"}}</option>
+                      <option value="itemModifierBlessingsTraveler">{{localize "YZECORIOLIS.IconTraveler"}}</option>
+                      <option value="itemModifierBlessingsLadyOfTears">{{localize "YZECORIOLIS.IconLadyOfTears"}}</option>
+                      <option value="itemModifierBlessingsFacelessOne">{{localize "YZECORIOLIS.IconFaceless"}}</option>
+                    </optgroup>
+                    <optgroup label="{{localize "YZECORIOLIS.Prayers"}}">
+                      <option value="itemModifierPrayersAll">{{localize "YZECORIOLIS.PrayersAll"}}</option>
+                      <option value="itemModifierPrayersMessenger">{{localize "YZECORIOLIS.IconMessenger"}}</option>
+                      <option value="itemModifierPrayersDancer">{{localize "YZECORIOLIS.IconDancer"}}</option>
+                      <option value="itemModifierPrayersGambler">{{localize "YZECORIOLIS.IconGambler"}}</option>
+                      <option value="itemModifierPrayersDeckhand">{{localize "YZECORIOLIS.IconDeckhand"}}</option>
+                      <option value="itemModifierPrayersMerchant">{{localize "YZECORIOLIS.IconMerchant"}}</option>
+                      <option value="itemModifierPrayersJudge">{{localize "YZECORIOLIS.IconJudge"}}</option>
+                      <option value="itemModifierPrayersTraveler">{{localize "YZECORIOLIS.IconTraveler"}}</option>
+                      <option value="itemModifierPrayersLadyOfTears">{{localize "YZECORIOLIS.IconLadyOfTears"}}</option>
+                      <option value="itemModifierPrayersFacelessOne">{{localize "YZECORIOLIS.IconFaceless"}}</option>
                     </optgroup>
                     <optgroup label="{{localize "YZECORIOLIS.Other"}}">
                       <option value="itemModifierHP">{{localize "YZECORIOLIS.HitPoints"}}</option>

--- a/templates/sidebar/roll.html
+++ b/templates/sidebar/roll.html
@@ -220,7 +220,11 @@
         <div class="dice-formula dice-push yzecoriolis">
             <em>{{localize "YZECORIOLIS.PushedRoll"}}</em>
             {{#if prayerBonus}}
-            <em> (+{{prayerBonus}})</em>
+              <em> (+{{prayerBonus}})</em>
+            {{/if}}
+            {{#if prayerModifiersChecked}}
+              <br>
+              <em>{{prayerModifiersChecked}}</em>
             {{/if}}
         </div>
         {{/if}}


### PR DESCRIPTION
# new Options

- All Attributes
- All General Skills
- All Advanced Skills
- Blessings
- Prayers

![image](https://github.com/winks-vtt/yze-coriolis/assets/36819852/1ec02f5d-a744-42f8-89ab-bb45d0e788a2) ![image](https://github.com/winks-vtt/yze-coriolis/assets/36819852/41774c1e-418a-4ffe-8bcb-6c23aa251c16)


# bug fixx
### unlimited rerolls
After the first reroll/prayer the button for rerolls were greyed out but it still worked indefinitely.
This is fixxed now and it even gets an error-message.
![image](https://github.com/winks-vtt/yze-coriolis/assets/36819852/0a0f70e9-00e5-4356-953a-28777227010e)

### error while deleting itemModifiers
There were some insignificant console-errors when an itemModifier was deleted.
It is fixxed now.


# Why All [Attributes/Skills/etc]?
Some talents and especially critical injurys have modifiers for "all [something]" like:
`Critical Injury 15: Concussion - Stunned for one turn, then -1 to all advanced skills.`
And you don't want to put 8 or more modifiers there if you can do that with one. :D


# What does Blessings do?
If you got the blessing of an icon (via roleplay, the talent Blessing, talismans etc) you get modifiers for that.
You can choose an Icon (or "All Blessings") as itemModifier and the modifers counts forword the corresponding skills:
CRB p.57
![image](https://github.com/winks-vtt/yze-coriolis/assets/36819852/ac14c0d9-b38e-4030-abb6-c7ae52486ff0)


# What does Prayers do?
Same as Blessings but are modifiers for the prayer-mechnic (rerolls).
![image](https://github.com/winks-vtt/yze-coriolis/assets/36819852/adb3069a-9073-4b70-913d-f37f89c832e3)